### PR TITLE
Fixed flexbox layout bug when container size changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests
 testWorkflows
 .vscode
 todo.txt
+Flexbox2.lua

--- a/BasaltLS.lua
+++ b/BasaltLS.lua
@@ -1,8 +1,1886 @@
 ---@meta
 
+---@class BigFontText
+local BigFontText = {}
+
+---@class Image : VisualElement
+---@field offsetX number Horizontal offset for viewing larger images
+---@field currentFrame number Current animation frame
+---@field offsetY number Vertical offset for viewing larger images
+---@field bimg table The bimg image data
+---@field autoResize boolean Whether to automatically resize the image when content exceeds bounds
+local Image = {}
+
+---Gets the value of the AutoResize property.
+---@param self Image self
+---@return boolean false Whether to automatically resize the image when content exceeds bounds
+function Image:getAutoResize(self) end
+
+---Sets the foreground color at the specified position
+---@param x number The x position
+---@param y number The y position
+---@param pattern string The foreground color pattern
+---@return Image self The Image instance
+function Image:setFg(x, y, pattern) end
+
+---Sets the text at the specified position
+---@param x number The x position
+---@param y number The y position
+---@param text string The text to set
+---@return Image self The Image instance
+function Image:setText(x, y, text) end
+
+---Gets the background color at the specified position
+---@param x number The x position
+---@param y number The y position
+---@param length number The length of the background color pattern to get
+---@return string bg The background color pattern
+function Image:getBg(x, y, length) end
+
+---Sets the value of the Bimg property.
+---@param self Image self
+---@param Bimg table The bimg image data
+function Image:setBimg(self, Bimg) end
+
+---Gets the value of the CurrentFrame property.
+---@param self Image self
+---@return number 1 Current animation frame
+function Image:getCurrentFrame(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Image:render() end
+
+---Resizes the image to the specified width and height
+---@param width number The new width of the image
+---@param height number The new height of the image
+---@return Image self The Image instance
+function Image:resizeImage(width, height) end
+
+---Sets the background color at the specified position
+---@param x number The x position
+---@param y number The y position
+---@param pattern string The background color pattern
+---@return Image self The Image instance
+function Image:setBg(x, y, pattern) end
+
+---Gets the metadata of the image
+---@return table metadata The metadata of the image
+function Image:getMetadata() end
+
+---Gets the value of the Bimg property.
+---@param self Image self
+---@return table {} The bimg image data
+function Image:getBimg(self) end
+
+---Sets the metadata of the image
+---@param key string The key of the metadata to set
+---@param value string The value of the metadata to set
+---@return Image self The Image instance
+function Image:setMetadata(key, value) end
+
+---Gets the text at the specified position
+---@param x number The x position
+---@param y number The y position
+---@param length number The length of the text to get
+---@return string text The text at the specified position
+function Image:getText(x, y, length) end
+
+---Updates the specified frame with the provided data
+---@param frameIndex number The index of the frame to update
+---@param frame table The new frame data
+---@return Image self The Image instance
+function Image:updateFrame(frameIndex, frame) end
+
+---Gets the foreground color at the specified position
+---@param x number The x position
+---@param y number The y position
+---@param length number The length of the foreground color pattern to get
+---@return string fg The foreground color pattern
+function Image:getFg(x, y, length) end
+
+---Advances to the next frame in the animation
+---@return Image self The Image instance
+function Image:nextFrame() end
+
+---Sets the pixel at the specified position
+---@param x number The x position
+---@param y number The y position
+---@param char string The character to set
+---@param fg string The foreground color pattern
+---@param bg string The background color pattern
+---@return Image self The Image instance
+function Image:setPixel(x, y, char, fg, bg) end
+
+---Gets the specified frame
+---@param frameIndex number The index of the frame to get
+---@return table frame The frame data
+function Image:getFrame(frameIndex) end
+
+---Adds a new frame to the image
+---@return Image self The Image instance
+function Image:addFrame() end
+
+---Gets the value of the OffsetY property.
+---@param self Image self
+---@return number 0 Vertical offset for viewing larger images
+function Image:getOffsetY(self) end
+
+---Gets the value of the OffsetX property.
+---@param self Image self
+---@return number 0 Horizontal offset for viewing larger images
+function Image:getOffsetX(self) end
+
+---Sets the value of the OffsetX property.
+---@param self Image self
+---@param OffsetX number Horizontal offset for viewing larger images
+function Image:setOffsetX(self, OffsetX) end
+
+---Sets the value of the CurrentFrame property.
+---@param self Image self
+---@param CurrentFrame number Current animation frame
+function Image:setCurrentFrame(self, CurrentFrame) end
+
+---Sets the value of the OffsetY property.
+---@param self Image self
+---@param OffsetY number Vertical offset for viewing larger images
+function Image:setOffsetY(self, OffsetY) end
+
+---Gets the size of the image
+---@return number width The width of the image
+---@return number height The height of the image
+function Image:getImageSize() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Image self The initialized instance
+---@protected
+function Image:init(props, basalt) end
+
+---Gets pixel information at position
+---@param x number X position
+---@param y number Y position
+---@return number ? fg Foreground color
+---@return number ? bg Background color
+---@return string ? char Character at position
+function Image:getPixelData(x, y) end
+
+---Sets the value of the AutoResize property.
+---@param self Image self
+---@param AutoResize boolean Whether to automatically resize the image when content exceeds bounds
+function Image:setAutoResize(self, AutoResize) end
+
+---@class BaseFrame : Container
+---@field term term term.current() The terminal or (monitor) peripheral object to render to
+local BaseFrame = {}
+
+---Sets the cursor position
+---@param x number The x position to set the cursor to
+---@param y number The y position to set the cursor to
+---@param blink boolean Whether the cursor should blink
+function BaseFrame:setCursor(x, y, blink) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to render to
+---@param y number The y position to render to
+---@param text string The text to render
+---@param bg colors The background color
+---@protected
+function BaseFrame:drawText(x, y, text, bg) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function BaseFrame:render() end
+
+---Gets the value of the Term property.
+---@param self BaseFrame self
+---@return term |peripheral term.current() The terminal or (monitor) peripheral object to render to
+function BaseFrame:getTerm(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was released
+---@param x number The x position of the mouse
+---@param y number The y position of the mouse
+---@protected
+function BaseFrame:mouse_up(button, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return table self The initialized instance
+---@protected
+function BaseFrame:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the mouse
+---@param y number The y position of the mouse
+---@protected
+function BaseFrame:mouse_click(button, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was released
+---@protected
+function BaseFrame:key_up(key) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to render to
+---@param y number The y position to render to
+---@param text string The text to render
+---@param fg colors The foreground color
+---@protected
+function BaseFrame:textFg(x, y, text, fg) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function BaseFrame:term_resize() end
+
+function BaseFrame:dispatchEvent() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to render to
+---@param y number The y position to render to
+---@param width number The width of the text
+---@param height number The height of the text
+---@param text string The text to render
+---@param fg string The foreground color
+---@param bg string The background color
+---@protected
+function BaseFrame:multiBlit(x, y, width, height, text, fg, bg) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to render to
+---@param y number The y position to render to
+---@param text string The text to render
+---@param bg colors The background color
+---@protected
+function BaseFrame:textBg(x, y, text, bg) end
+
+---Toggles the debug log frame
+---@param self BaseFrame The frame to toggle debug log for
+function BaseFrame.toggleConsole(self) end
+
+---Sets the value of the Term property.
+---@param self BaseFrame self
+---@param Term term term.current() The terminal or (monitor) peripheral object to render to
+function BaseFrame:setTerm(self, Term) end
+
+---Shows the debug log frame
+---@param self BaseFrame The frame to show debug log in
+function BaseFrame.openConsole(self) end
+
+---Hides the debug log frame
+---@param self BaseFrame The frame to hide debug log for
+function BaseFrame.closeConsole(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param char string The character that was pressed
+---@protected
+function BaseFrame:char(char) end
+
+function BaseFrame:drawFg() end
+
+function BaseFrame.setup() end
+
+function BaseFrame:drawBg() end
+
+---Initializes a new state for this element
+---@param self BaseFrame The element to initialize state for
+---@param name string The name of the state
+---@param default any The default value of the state
+---@return BaseFrame self The element instance
+function BaseFrame:initializeState(self, name, default) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was pressed
+---@protected
+function BaseFrame:key(key) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param name string The name of the monitor that was touched
+---@param x number The x position of the mouse
+---@param y number The y position of the mouse
+---@protected
+function BaseFrame:monitor_touch(name, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to render to
+---@param y number The y position to render to
+---@param text string The text to render
+---@param fg string The foreground color
+---@param bg string The background color
+---@protected
+function BaseFrame:blit(x, y, text, fg, bg) end
+
+---@class Graph : VisualElement
+---@field minValue number The minimum value of the graph
+---@field series table The series of the graph
+---@field maxValue number The maximum value of the graph
+local Graph = {}
+
+---@param name string The name of the series
+---@param count number The number of points in the series
+---@return Graph self The graph instance
+function Graph:setSeriesPointCount(name, count) end
+
+---@param name string The name of the series
+---@return table ? series The series
+function Graph:getSeries(name) end
+
+---@param name string The name of the series
+---@param visible boolean Whether the series should be visible
+---@return Graph self The graph instance
+function Graph:changeSeriesVisibility(name, visible) end
+
+---Gets the value of the MaxValue property.
+---@param self Graph self
+---@return number 100 The maximum value of the graph
+function Graph:getMaxValue(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Graph self The initialized instance
+---@protected
+function Graph:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Graph:render() end
+
+---Clears all points from a series
+---@return Graph self The graph instance
+function Graph:clear() end
+
+---Sets the value of the MaxValue property.
+---@param self Graph self
+---@param MaxValue number The maximum value of the graph
+function Graph:setMaxValue(self, MaxValue) end
+
+---Gets the value of the MinValue property.
+---@param self Graph self
+---@return number 0 The minimum value of the graph
+function Graph:getMinValue(self) end
+
+---Sets the value of the MinValue property.
+---@param self Graph self
+---@param MinValue number The minimum value of the graph
+function Graph:setMinValue(self, MinValue) end
+
+---@param name string The name of the series
+---@param value number The value of the point
+---@return Graph self The graph instance
+function Graph:addPoint(name, value) end
+
+---@param name string The name of the series
+---@return Graph self The graph instance
+function Graph:focusSeries(name) end
+
+---@param name string The name of the series
+---@return Graph self The graph instance
+function Graph:removeSeries(name) end
+
+---Sets the value of the Series property.
+---@param self Graph self
+---@param Series table The series of the graph
+function Graph:setSeries(self, Series) end
+
+---@param name string The name of the series
+---@param symbol string The symbol of the series
+---@param bgCol number The background color of the series
+---@param fgCol number The foreground color of the series
+---@param pointCount number The number of points in the series
+---@return Graph self The graph instance
+function Graph:addSeries(name, symbol, bgCol, fgCol, pointCount) end
+
+---@class Slider : VisualElement
+---@field sliderColor color Color of the slider handle
+---@field max number Maximum value for value conversion (maps slider position to this range)
+---@field horizontal boolean Whether the slider is horizontal (false for vertical)
+---@field step number Current position of the slider handle (1 to width/height)
+---@field barColor color Color of the slider track
+local Slider = {}
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The mouse button that was released
+---@param x number The x position of the release
+---@param y number The y position of the release
+---@return boolean handled Whether the event was handled
+---@protected
+function Slider:mouse_scroll(button, x, y) end
+
+---Sets the value of the BarColor property.
+---@param self Slider self
+---@param BarColor color Color of the slider track
+function Slider:setBarColor(self, BarColor) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Slider:render() end
+
+---Sets the value of the SliderColor property.
+---@param self Slider self
+---@param SliderColor color Color of the slider handle
+function Slider:setSliderColor(self, SliderColor) end
+
+---Gets the value of the Step property.
+---@param self Slider self
+---@return number 1 Current position of the slider handle (1 to width/height)
+function Slider:getStep(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Slider self The initialized instance
+---@protected
+function Slider:init(props, basalt) end
+
+---Sets the value of the Max property.
+---@param self Slider self
+---@param Max number Maximum value for value conversion (maps slider position to this range)
+function Slider:setMax(self, Max) end
+
+---Sets the value of the Horizontal property.
+---@param self Slider self
+---@param Horizontal boolean Whether the slider is horizontal (false for vertical)
+function Slider:setHorizontal(self, Horizontal) end
+
+---Gets the value of the BarColor property.
+---@param self Slider self
+---@return color gray Color of the slider track
+function Slider:getBarColor(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The mouse button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Slider:mouse_click(button, x, y) end
+
+---Gets the value of the Max property.
+---@param self Slider self
+---@return number 100 Maximum value for value conversion (maps slider position to this range)
+function Slider:getMax(self) end
+
+---Gets the current value of the slider
+---@return number value The current value (0 to max)
+function Slider:getValue() end
+
+---Sets the value of the Step property.
+---@param self Slider self
+---@param Step number Current position of the slider handle (1 to width/height)
+function Slider:setStep(self, Step) end
+
+---Registers a function to handle the onChange event.
+---@param value number
+---@param self Slider self
+---@param func function The function to be called when the event fires
+function Slider:onOnChange(self, func) end
+
+---Gets the value of the SliderColor property.
+---@param self Slider self
+---@return color blue Color of the slider handle
+function Slider:getSliderColor(self) end
+
+---Gets the value of the Horizontal property.
+---@param self Slider self
+---@return boolean true Whether the slider is horizontal (false for vertical)
+function Slider:getHorizontal(self) end
+
+---@class BarChart : Graph
+local BarChart = {}
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return BarChart self The initialized instance
+---@protected
+function BarChart:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function BarChart:render() end
+
+---@class basalt
+local basalt = {}
+
+---Removes a scheduled update
+---@param func thread The scheduled function to remove
+---@return boolean success Whether the scheduled function was removed
+function basalt.removeSchedule(func) end
+
+---Returns the active frame
+---@return BaseFrame ? BaseFrame The frame to set as active
+function basalt.getActiveFrame() end
+
+---Returns an element's class without creating a instance
+---@param name string The name of the element
+---@return table Element The element class
+function basalt.getElementClass(name) end
+
+---Returns the element manager instance
+---@return table ElementManager The element manager
+function basalt.getElementManager() end
+
+---Returns a Plugin API
+---@param name string The name of the plugin
+---@return table Plugin The plugin API
+function basalt.getAPI(name) end
+
+---Starts the Basalt runtime
+function basalt.run() end
+
+---Runs basalt once, can be used to update the UI manually, but you have to feed it the events
+function basalt.update() end
+
+---Gets or creates the main frame
+---@return BaseFrame BaseFrame The main frame instance
+function basalt.getMainFrame() end
+
+---Sets the active frame
+---@param frame BaseFrame The frame to set as active
+function basalt.setActiveFrame(frame) end
+
+---Stops the Basalt runtime
+function basalt.stop() end
+
+---Creates and returns a new UI element of the specified type.
+---@param type string The type of element to create (e.g. "Button", "Label", "BaseFrame")
+---@return table element The created element instance
+function basalt.create(type) end
+
+---Schedules a function to run in a coroutine
+---@param func function The function to schedule
+---@return thread func The scheduled function
+function basalt.schedule(func) end
+
+---Returns the focused frame
+---@return BaseFrame ? BaseFrame The focused frame
+function basalt.getFocus() end
+
+---Sets a frame as focused
+---@param frame BaseFrame The frame to set as focused
+function basalt.setFocus(frame) end
+
+---Creates and returns a new BaseFrame
+---@return BaseFrame BaseFrame The created frame instance
+function basalt.createFrame() end
+
+---Returns the error manager instance
+---@return table ErrorManager The error manager
+function basalt.getErrorManager() end
+
+---@class Input : VisualElement
+---@field focusedForeground color Foreground color when input is focused
+---@field focusedBackground color Background color when input is focused
+---@field placeholderColor color Color of the placeholder text
+---@field pattern string nil Regular expression pattern for input validation
+---@field cursorPos number The current cursor position in the text
+---@field placeholder string Text to display when input is empty
+---@field maxLength number nil Maximum length of input text (optional)
+---@field cursorColor number Color of the cursor
+---@field viewOffset number The horizontal scroll offset for viewing long text
+---@field text string The current text content of the input
+---@field replaceChar string Character to replace the input with (for password fields)
+local Input = {}
+
+---Sets the value of the Placeholder property.
+---@param self Input self
+---@param Placeholder string Text to display when input is empty
+function Input:setPlaceholder(self, Placeholder) end
+
+---Sets the value of the Pattern property.
+---@param self Input self
+---@param Pattern string nil Regular expression pattern for input validation
+function Input:setPattern(self, Pattern) end
+
+---Gets the value of the ViewOffset property.
+---@param self Input self
+---@return number 0 The horizontal scroll offset for viewing long text
+function Input:getViewOffset(self) end
+
+---Gets the value of the MaxLength property.
+---@param self Input self
+---@return number ? nil Maximum length of input text (optional)
+function Input:getMaxLength(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param char string The character that was typed
+---@return boolean handled Whether the event was handled
+---@protected
+function Input:char(char) end
+
+---Gets the value of the CursorPos property.
+---@param self Input self
+---@return number 1 The current cursor position in the text
+function Input:getCursorPos(self) end
+
+---Sets the value of the CursorColor property.
+---@param self Input self
+---@param CursorColor number Color of the cursor
+function Input:setCursorColor(self, CursorColor) end
+
+---Sets the value of the ViewOffset property.
+---@param self Input self
+---@param ViewOffset number The horizontal scroll offset for viewing long text
+function Input:setViewOffset(self, ViewOffset) end
+
+---Gets the value of the Placeholder property.
+---@param self Input self
+---@return string ... Text to display when input is empty
+function Input:getPlaceholder(self) end
+
+---Gets the value of the Pattern property.
+---@param self Input self
+---@return string ? nil Regular expression pattern for input validation
+function Input:getPattern(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Input:render() end
+
+---Sets the value of the FocusedBackground property.
+---@param self Input self
+---@param FocusedBackground color Background color when input is focused
+function Input:setFocusedBackground(self, FocusedBackground) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Input:blur() end
+
+---Sets the value of the PlaceholderColor property.
+---@param self Input self
+---@param PlaceholderColor color Color of the placeholder text
+function Input:setPlaceholderColor(self, PlaceholderColor) end
+
+---Sets the value of the ReplaceChar property.
+---@param self Input self
+---@param ReplaceChar string Character to replace the input with (for password fields)
+function Input:setReplaceChar(self, ReplaceChar) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Input:mouse_click(button, x, y) end
+
+---Sets the value of the Text property.
+---@param self Input self
+---@param Text string The current text content of the input
+function Input:setText(self, Text) end
+
+---Gets the value of the PlaceholderColor property.
+---@param self Input self
+---@return color gray Color of the placeholder text
+function Input:getPlaceholderColor(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Input self The initialized instance
+---@protected
+function Input:init(props, basalt) end
+
+---Updates the input's viewport
+---@return Input self The updated instance
+function Input:updateViewport() end
+
+---Gets the value of the Text property.
+---@param self Input self
+---@return string - The current text content of the input
+function Input:getText(self) end
+
+---Sets the value of the FocusedForeground property.
+---@param self Input self
+---@param FocusedForeground color Foreground color when input is focused
+function Input:setFocusedForeground(self, FocusedForeground) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was pressed
+---@return boolean handled Whether the event was handled
+---@protected
+function Input:key(key) end
+
+---Gets the value of the FocusedForeground property.
+---@param self Input self
+---@return color white Foreground color when input is focused
+function Input:getFocusedForeground(self) end
+
+---Sets the value of the CursorPos property.
+---@param self Input self
+---@param CursorPos number The current cursor position in the text
+function Input:setCursorPos(self, CursorPos) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Input:focus() end
+
+---Sets the cursor position and color
+---@param x number The x position of the cursor
+---@param y number The y position of the cursor
+---@param blink boolean Whether the cursor should blink
+---@param color number The color of the cursor
+function Input:setCursor(x, y, blink, color) end
+
+---Gets the value of the ReplaceChar property.
+---@param self Input self
+---@return string nil Character to replace the input with (for password fields)
+function Input:getReplaceChar(self) end
+
+---Gets the value of the CursorColor property.
+---@param self Input self
+---@return number nil Color of the cursor
+function Input:getCursorColor(self) end
+
+---Sets the value of the MaxLength property.
+---@param self Input self
+---@param MaxLength number nil Maximum length of input text (optional)
+function Input:setMaxLength(self, MaxLength) end
+
+---Gets the value of the FocusedBackground property.
+---@param self Input self
+---@return color blue Background color when input is focused
+function Input:getFocusedBackground(self) end
+
+---@class Program : VisualElement
+---@field program table The program instance
+---@field running boolean Whether the program is running
+---@field path string The path to the program
+local Program = {}
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Program self The initialized instance
+---@protected
+function Program:init(props, basalt) end
+
+---Gets the value of the Running property.
+---@param self Program self
+---@return boolean false Whether the program is running
+function Program:getRunning(self) end
+
+---Sets the value of the Program property.
+---@param self Program self
+---@param Program table The program instance
+function Program:setProgram(self, Program) end
+
+---Gets the value of the Program property.
+---@param self Program self
+---@return table nil The program instance
+function Program:getProgram(self) end
+
+---Gets the value of the Path property.
+---@param self Program self
+---@return string "" The path to the program
+function Program:getPath(self) end
+
+---Executes a program
+---@param path string The path to the program
+---@return Program self The Program instance
+function Program:execute(path) end
+
+---Sets the value of the Path property.
+---@param self Program self
+---@param Path string The path to the program
+function Program:setPath(self, Path) end
+
+---Sets the value of the Running property.
+---@param self Program self
+---@param Running boolean Whether the program is running
+function Program:setRunning(self, Running) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Program:render() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Program:focus() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param event string The event to handle
+---@return any result The event result
+---@protected
+function Program:dispatchEvent(event) end
+
+---Registers a callback for the program's error event, if the function returns false, the program won't stop
+---@param fn function The callback function to register
+---@return Program self The Program instance
+function Program:onError(fn) end
+
+---Sends an event to the program
+---@param event string The event to send
+---@return Program self The Program instance
+function Program:sendEvent(event) end
+
+---@class Flexbox : Container
+---@field flexJustifyContent string The alignment of flex items along the main axis
+---@field flexDirection string The direction of the flexbox layout "row" or "column"
+---@field flexUpdateLayout boolean Whether to update the layout of the flexbox
+---@field flexWrap boolean Whether to wrap flex items onto multiple lines
+---@field flexSpacing number The spacing between flex items
+local Flexbox = {}
+
+---Sets the value of the FlexSpacing property.
+---@param self Flexbox self
+---@param FlexSpacing number The spacing between flex items
+function Flexbox:setFlexSpacing(self, FlexSpacing) end
+
+---Sets the value of the FlexUpdateLayout property.
+---@param self Flexbox self
+---@param FlexUpdateLayout boolean Whether to update the layout of the flexbox
+function Flexbox:setFlexUpdateLayout(self, FlexUpdateLayout) end
+
+---Gets the value of the FlexJustifyContent property.
+---@param self Flexbox self
+---@return string "flex-start" The alignment of flex items along the main axis
+function Flexbox:getFlexJustifyContent(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Flexbox:render() end
+
+---Gets the value of the FlexUpdateLayout property.
+---@param self Flexbox self
+---@return boolean false Whether to update the layout of the flexbox
+function Flexbox:getFlexUpdateLayout(self) end
+
+---Adds a new line break to the flexbox
+---@param self Flexbox The element itself
+---@return Flexbox 
+function Flexbox:addLineBreak(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param element Element The child element to remove
+---@return Flexbox self The flexbox instance
+---@protected
+function Flexbox:removeChild(element) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Flexbox self The initialized instance
+---@protected
+function Flexbox:init(props, basalt) end
+
+---Gets the value of the FlexDirection property.
+---@param self Flexbox self
+---@return string "row" The direction of the flexbox layout "row" or "column"
+function Flexbox:getFlexDirection(self) end
+
+---Sets the value of the FlexDirection property.
+---@param self Flexbox self
+---@param FlexDirection string The direction of the flexbox layout "row" or "column"
+function Flexbox:setFlexDirection(self, FlexDirection) end
+
+---Gets the value of the FlexSpacing property.
+---@param self Flexbox self
+---@return number 1 The spacing between flex items
+function Flexbox:getFlexSpacing(self) end
+
+---Sets the value of the FlexWrap property.
+---@param self Flexbox self
+---@param FlexWrap boolean Whether to wrap flex items onto multiple lines
+function Flexbox:setFlexWrap(self, FlexWrap) end
+
+---Adds a child element to the flexbox
+---@param element Element The child element to add
+---@return Flexbox self The flexbox instance
+function Flexbox:addChild(element) end
+
+---Sets the value of the FlexJustifyContent property.
+---@param self Flexbox self
+---@param FlexJustifyContent string The alignment of flex items along the main axis
+function Flexbox:setFlexJustifyContent(self, FlexJustifyContent) end
+
+---Gets the value of the FlexWrap property.
+---@param self Flexbox self
+---@return boolean false Whether to wrap flex items onto multiple lines
+function Flexbox:getFlexWrap(self) end
+
+---@class Dropdown : List
+---@field isOpen boolean Whether the dropdown menu is currently open
+---@field dropSymbol string The symbol to show for dropdown indication
+---@field dropdownHeight number Maximum height of the dropdown menu when open
+---@field selectedText string The text to show when no item is selected
+local Dropdown = {}
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Dropdown:mouse_click(button, x, y) end
+
+---Gets the value of the DropSymbol property.
+---@param self Dropdown self
+---@return string "\31" The symbol to show for dropdown indication
+function Dropdown:getDropSymbol(self) end
+
+---Sets the value of the SelectedText property.
+---@param self Dropdown self
+---@param SelectedText string The text to show when no item is selected
+function Dropdown:setSelectedText(self, SelectedText) end
+
+---Gets the value of the IsOpen property.
+---@param self Dropdown self
+---@return boolean false Whether the dropdown menu is currently open
+function Dropdown:getIsOpen(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Dropdown self The initialized instance
+---@protected
+function Dropdown:init(props, basalt) end
+
+---Sets the value of the IsOpen property.
+---@param self Dropdown self
+---@param IsOpen boolean Whether the dropdown menu is currently open
+function Dropdown:setIsOpen(self, IsOpen) end
+
+---Sets the value of the DropSymbol property.
+---@param self Dropdown self
+---@param DropSymbol string The symbol to show for dropdown indication
+function Dropdown:setDropSymbol(self, DropSymbol) end
+
+---Gets the value of the SelectedText property.
+---@param self Dropdown self
+---@return string "" The text to show when no item is selected
+function Dropdown:getSelectedText(self) end
+
+---Gets the value of the DropdownHeight property.
+---@param self Dropdown self
+---@return number 5 Maximum height of the dropdown menu when open
+function Dropdown:getDropdownHeight(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Dropdown:render() end
+
+---Sets the value of the DropdownHeight property.
+---@param self Dropdown self
+---@param DropdownHeight number Maximum height of the dropdown menu when open
+function Dropdown:setDropdownHeight(self, DropdownHeight) end
+
+---@class Frame : Container
+---@field draggable boolean Whether the frame is draggable
+---@field draggingMap table The map of dragging positions
+local Frame = {}
+
+---Sets the value of the Draggable property.
+---@param self Frame self
+---@param Draggable boolean Whether the frame is draggable
+function Frame:setDraggable(self, Draggable) end
+
+---Gets the value of the Draggable property.
+---@param self Frame self
+---@return boolean false Whether the frame is draggable
+function Frame:getDraggable(self) end
+
+---Gets the value of the DraggingMap property.
+---@param self Frame self
+---@return table {} The map of dragging positions
+function Frame:getDraggingMap(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the drag position
+---@param y number The y position of the drag position
+---@return boolean handled Whether the event was handled
+---@protected
+function Frame:mouse_drag(button, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Frame self The initialized instance
+---@protected
+function Frame:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was released
+---@param x number The x position of the release
+---@param y number The y position of the release
+---@return boolean handled Whether the event was handled
+---@protected
+function Frame:mouse_up(button, x, y) end
+
+---Sets the value of the DraggingMap property.
+---@param self Frame self
+---@param DraggingMap table The map of dragging positions
+function Frame:setDraggingMap(self, DraggingMap) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Frame:mouse_click(button, x, y) end
+
+---@class Container : VisualElement
+---@field childrenEventsSorted boolean Whether the children events are sorted
+---@field offsetY number Vertical content offset
+---@field children table The children of the container
+---@field offsetX number Horizontal content offset
+---@field visibleChildrenEvents table The visible children events of the container
+---@field eventListenerCount table The event listener count of the container
+---@field focusedChild table The focused child of the container
+---@field childrenEvents table The children events of the container
+---@field childrenSorted boolean Whether the children are sorted
+---@field visibleChildren table The visible children of the container
+local Container = {}
+
+---Creates a new Label element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Label element A new Label element.
+function Container:addLabel(self, props) end
+
+---Adds a child to the container
+---@param child table The child to add
+---@return Container self The container instance
+function Container:addChild(child) end
+
+---Sets the value of the EventListenerCount property.
+---@param self Container self
+---@param EventListenerCount table The event listener count of the container
+function Container:setEventListenerCount(self, EventListenerCount) end
+
+---Creates a new Switch element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Switch element A new Switch element.
+function Container:addSwitch(self, props) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:mouse_up(button, x, y) end
+
+---Removes a child from the container
+---@param path string The path to the child to remove
+---@return Container ? self The container instance
+function Container:getChild(path) end
+
+---Removes a child from the container
+---@param child table The child to remove
+---@return Container self The container instance
+function Container:removeChild(child) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was released
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:key_up(key) end
+
+---Creates a new TextBox element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return TextBox element A new TextBox element.
+function Container:addTextBox(self, props) end
+
+---Sets the value of the VisibleChildren property.
+---@param self Container self
+---@param VisibleChildren table The visible children of the container
+function Container:setVisibleChildren(self, VisibleChildren) end
+
+---Sets the value of the OffsetX property.
+---@param self Container self
+---@param OffsetX number Horizontal content offset
+function Container:setOffsetX(self, OffsetX) end
+
+---Creates a new Table element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Table element A new Table element.
+function Container:addTable(self, props) end
+
+---Creates a new List element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return List element A new List element.
+function Container:addList(self, props) end
+
+---Creates a new BaseFrame element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return BaseFrame element A new BaseFrame element.
+function Container:addBaseFrame(self, props) end
+
+---Creates a new Slider element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Slider element A new Slider element.
+function Container:addSlider(self, props) end
+
+---Creates a new Frame element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Frame element A new Frame element.
+function Container:addFrame(self, props) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:mouse_click(button, x, y) end
+
+---Creates a new Graph element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Graph element A new Graph element.
+function Container:addGraph(self, props) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param event string The event to handle
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:handleEvent(event) end
+
+---Creates a new Menu element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Menu element A new Menu element.
+function Container:addMenu(self, props) end
+
+---Gets the value of the Children property.
+---@param self Container self
+---@return table {} The children of the container
+function Container:getChildren(self) end
+
+---Creates a new BigFont element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return BigFont element A new BigFont element.
+function Container:addBigFont(self, props) end
+
+---Sets the value of the ChildrenEvents property.
+---@param self Container self
+---@param ChildrenEvents table The children events of the container
+function Container:setChildrenEvents(self, ChildrenEvents) end
+
+function Container:drawBg() end
+
+---Logs benchmark statistics for a container and all its children
+---@param methodName string The method to log
+---@return Container self The container instance
+function Container:logContainerBenchmarks(methodName) end
+
+---Gets the value of the VisibleChildren property.
+---@param self Container self
+---@return table {} The visible children of the container
+function Container:getVisibleChildren(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw the text
+---@param y number The y position to draw the text
+---@param text string The text to draw
+---@param fg color The foreground color of the text
+---@return Container self The container instance
+---@protected
+function Container:textFg(x, y, text, fg) end
+
+---Sets the value of the ChildrenEventsSorted property.
+---@param self Container self
+---@param ChildrenEventsSorted boolean Whether the children events are sorted
+function Container:setChildrenEventsSorted(self, ChildrenEventsSorted) end
+
+---Registers the children events of the container
+---@param child table The child to register events for
+---@param eventName string The event name to register
+---@return Container self The container instance
+function Container:registerChildEvent(child, eventName) end
+
+---Creates a new BaseElement element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return BaseElement element A new BaseElement element.
+function Container:addBaseElement(self, props) end
+
+---Gets the value of the FocusedChild property.
+---@param self Container self
+---@return table nil The focused child of the container
+function Container:getFocusedChild(self) end
+
+---Creates a new Tree element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Tree element A new Tree element.
+function Container:addTree(self, props) end
+
+---Unregisters the children events of the container
+---@param child table The child to unregister events for
+---@param eventName string The event name to unregister
+---@return Container self The container instance
+function Container:unregisterChildEvent(child, eventName) end
+
+---Creates a new ProgressBar element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return ProgressBar element A new ProgressBar element.
+function Container:addProgressBar(self, props) end
+
+---Creates a new Dropdown element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Dropdown element A new Dropdown element.
+function Container:addDropdown(self, props) end
+
+---Gets the value of the ChildrenSorted property.
+---@param self Container self
+---@return boolean true Whether the children are sorted
+function Container:getChildrenSorted(self) end
+
+---Creates a new Input element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Input element A new Input element.
+function Container:addInput(self, props) end
+
+---Sets the value of the ChildrenSorted property.
+---@param self Container self
+---@param ChildrenSorted boolean Whether the children are sorted
+function Container:setChildrenSorted(self, ChildrenSorted) end
+
+---Clears the container
+---@return Container self The container instance
+function Container:clear() end
+
+---Creates a new Checkbox element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Checkbox element A new Checkbox element.
+function Container:addCheckbox(self, props) end
+
+---Gets the value of the OffsetX property.
+---@param self Container self
+---@return number 0 Horizontal content offset
+function Container:getOffsetX(self) end
+
+---Sorts the children of the container
+---@return Container self The container instance
+function Container:sortChildren() end
+
+---Creates a new Display element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Display element A new Display element.
+function Container:addDisplay(self, props) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw the text
+---@param y number The y position to draw the text
+---@param width number The width of the text
+---@param height number The height of the text
+---@param text string The text to draw
+---@param fg string The foreground color of the text
+---@param bg string The background color of the text
+---@return Container self The container instance
+---@protected
+function Container:multiBlit(x, y, width, height, text, fg, bg) end
+
+---Creates a new Program element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Program element A new Program element.
+function Container:addProgram(self, props) end
+
+---Enables debugging for this container and all its children
+---@param self Container The container to debug
+---@param level number The debug level
+function Container.debugChildren(self, level) end
+
+---Gets the value of the ChildrenEventsSorted property.
+---@param self Container self
+---@return boolean true Whether the children events are sorted
+function Container:getChildrenEventsSorted(self) end
+
+---Creates a new LineChart element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return LineChart element A new LineChart element.
+function Container:addLineChart(self, props) end
+
+---Creates a new Flexbox element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Flexbox element A new Flexbox element.
+function Container:addFlexbox(self, props) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw the text
+---@param y number The y position to draw the text
+---@param text string The text to draw
+---@param fg string The foreground color of the text
+---@param bg string The background color of the text
+---@return Container self The container instance
+---@protected
+function Container:blit(x, y, text, fg, bg) end
+
+---Sets the value of the Children property.
+---@param self Container self
+---@param Children table The children of the container
+function Container:setChildren(self, Children) end
+
+---Creates a new Container element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Container element A new Container element.
+function Container:addContainer(self, props) end
+
+---Gets the value of the VisibleChildrenEvents property.
+---@param self Container self
+---@return table {} The visible children events of the container
+function Container:getVisibleChildrenEvents(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw the text
+---@param y number The y position to draw the text
+---@param text string The text to draw
+---@param bg color The background color of the text
+---@return Container self The container instance
+---@protected
+function Container:textBg(x, y, text, bg) end
+
+---Sorts the children events of the container
+---@param eventName string The event name to sort
+---@return Container self The container instance
+function Container:sortChildrenEvents(eventName) end
+
+---Unregisters the children events of the container
+---@param child table The child to unregister events for
+---@return Container self The container instance
+function Container:removeChildrenEvents(child) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param _ number unknown
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:mouse_move(_, x, y) end
+
+---Creates a new Button element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Button element A new Button element.
+function Container:addButton(self, props) end
+
+function Container:drawFg() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:mouse_drag(button, x, y) end
+
+---Registers the children events of the container
+---@param child table The child to register events for
+---@return Container self The container instance
+function Container:registerChildrenEvents(child) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@protected
+function Container:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@protected
+function Container:mouse_release(button, x, y) end
+
+---Stops benchmarking for a container and all its children
+---@param methodName string The method to stop benchmarking
+---@return Container self The container instance
+function Container:stopContainerBenchmark(methodName) end
+
+---Gets the value of the EventListenerCount property.
+---@param self Container self
+---@return table {} The event listener count of the container
+function Container:getEventListenerCount(self) end
+
+---Enables benchmarking for a container and all its children
+---@param methodName string The method to benchmark
+---@return Container self The container instance
+function Container:benchmarkContainer(methodName) end
+
+---Gets the value of the ChildrenEvents property.
+---@param self Container self
+---@return table {} The children events of the container
+function Container:getChildrenEvents(self) end
+
+---Creates a new Image element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Image element A new Image element.
+function Container:addImage(self, props) end
+
+---Gets the value of the OffsetY property.
+---@param self Container self
+---@return number 0 Vertical content offset
+function Container:getOffsetY(self) end
+
+---Returns whether a child is visible
+---@param child table The child to check
+---@return boolean boolean the child is visible
+function Container:isChildVisible(child) end
+
+---Sets the value of the VisibleChildrenEvents property.
+---@param self Container self
+---@param VisibleChildrenEvents table The visible children events of the container
+function Container:setVisibleChildrenEvents(self, VisibleChildrenEvents) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was pressed
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:key(key) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param char string The character that was pressed
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:char(char) end
+
+function Container:drawText() end
+
+---Sets the value of the FocusedChild property.
+---@param self Container self
+---@param FocusedChild table The focused child of the container
+function Container:setFocusedChild(self, FocusedChild) end
+
+---Creates a new VisualElement element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return VisualElement element A new VisualElement element.
+function Container:addVisualElement(self, props) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param direction number The direction of the scroll
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Container:mouse_scroll(direction, x, y) end
+
+---Calls a event on all children
+---@param visibleOnly boolean Whether to only call the event on visible children
+---@param event string The event to call
+---@return boolean handled Whether the event was handled
+---@return table ? child The child that handled the event
+function Container:callChildrenEvent(visibleOnly, event) end
+
+---Creates a new Scrollbar element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return Scrollbar element A new Scrollbar element.
+function Container:addScrollbar(self, props) end
+
+---Sets the value of the OffsetY property.
+---@param self Container self
+---@param OffsetY number Vertical content offset
+function Container:setOffsetY(self, OffsetY) end
+
+---Creates a new BarChart element.
+---@param self Container self
+---@param props? table Optional: properties for the element.
+---@return BarChart element A new BarChart element.
+function Container:addBarChart(self, props) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Container:render() end
+
+---@class Table : VisualElement
+---@field sortColumn number nil Currently sorted column index
+---@field selectedRow number nil Currently selected row index
+---@field selectedColor color Background color of selected row
+---@field scrollOffset number Current scroll position
+---@field data table The table data as array of row arrays
+---@field columns table List of column definitions with {name, width} properties
+---@field sortDirection string Sort direction ("asc" or "desc")
+---@field headerColor color Color of the column headers
+---@field gridColor color Color of grid lines
+local Table = {}
+
+---Gets the value of the HeaderColor property.
+---@param self Table self
+---@return color blue Color of the column headers
+function Table:getHeaderColor(self) end
+
+---Gets the value of the Columns property.
+---@param self Table self
+---@return table {} List of column definitions with {name, width} properties
+function Table:getColumns(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param direction number The scroll direction (-1 up, 1 down)
+---@param x number The x position of the scroll
+---@param y number The y position of the scroll
+---@return boolean handled Whether the event was handled
+---@protected
+function Table:mouse_scroll(direction, x, y) end
+
+---Gets the value of the Data property.
+---@param self Table self
+---@return table {} The table data as array of row arrays
+function Table:getData(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Table self The initialized instance
+---@protected
+function Table:init(props, basalt) end
+
+---Sets the value of the ScrollOffset property.
+---@param self Table self
+---@param ScrollOffset number Current scroll position
+function Table:setScrollOffset(self, ScrollOffset) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Table:render() end
+
+---Sets the value of the SelectedColor property.
+---@param self Table self
+---@param SelectedColor color Background color of selected row
+function Table:setSelectedColor(self, SelectedColor) end
+
+---Sets the value of the SelectedRow property.
+---@param self Table self
+---@param SelectedRow number nil Currently selected row index
+function Table:setSelectedRow(self, SelectedRow) end
+
+---Sets the value of the GridColor property.
+---@param self Table self
+---@param GridColor color Color of grid lines
+function Table:setGridColor(self, GridColor) end
+
+---Gets the value of the GridColor property.
+---@param self Table self
+---@return color gray Color of grid lines
+function Table:getGridColor(self) end
+
+---Sets the value of the Columns property.
+---@param self Table self
+---@param Columns table List of column definitions with {name, width} properties
+function Table:setColumns(self, Columns) end
+
+---Sets the value of the HeaderColor property.
+---@param self Table self
+---@param HeaderColor color Color of the column headers
+function Table:setHeaderColor(self, HeaderColor) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function Table:mouse_click(button, x, y) end
+
+---Sets the value of the SortDirection property.
+---@param self Table self
+---@param SortDirection string Sort direction ("asc" or "desc")
+function Table:setSortDirection(self, SortDirection) end
+
+---Sets the value of the SortColumn property.
+---@param self Table self
+---@param SortColumn number nil Currently sorted column index
+function Table:setSortColumn(self, SortColumn) end
+
+---Gets the value of the ScrollOffset property.
+---@param self Table self
+---@return number 0 Current scroll position
+function Table:getScrollOffset(self) end
+
+---Gets the value of the SortColumn property.
+---@param self Table self
+---@return number ? nil Currently sorted column index
+function Table:getSortColumn(self) end
+
+---Gets the value of the SelectedRow property.
+---@param self Table self
+---@return number ? nil Currently selected row index
+function Table:getSelectedRow(self) end
+
+---Gets the value of the SelectedColor property.
+---@param self Table self
+---@return color lightBlue Background color of selected row
+function Table:getSelectedColor(self) end
+
+---Sets the value of the Data property.
+---@param self Table self
+---@param Data table The table data as array of row arrays
+function Table:setData(self, Data) end
+
+---Gets the value of the SortDirection property.
+---@param self Table self
+---@return string "asc" Sort direction ("asc" or "desc")
+function Table:getSortDirection(self) end
+
+---Sorts the table data by column
+---@param columnIndex number The index of the column to sort by
+---@param fn function ? Optional custom sorting function
+---@return Table self The Table instance
+function Table:sortData(columnIndex, fn) end
+
+---@class ThemeAPI
+local ThemeAPI = {}
+
+---Loads a theme from a JSON file
+---@param path string Path to the theme JSON file
+function ThemeAPI.loadTheme(path) end
+
+---Sets the current theme
+---@param newTheme table The theme configuration to set
+function ThemeAPI.setTheme(newTheme) end
+
+---Gets the current theme configuration
+---@return table theme The current theme configuration
+function ThemeAPI.getTheme() end
+
+---@class Checkbox : VisualElement
+---@field text string Text to display
+---@field autoSize boolean Whether to automatically size the checkbox
+---@field checkedText string when checked
+---@field checked boolean checkbox is checked
+local Checkbox = {}
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean Clicked Whether the event was handled
+---@protected
+function Checkbox:mouse_click(button, x, y) end
+
+---Sets the value of the Text property.
+---@param self Checkbox self
+---@param Text string Text to display
+function Checkbox:setText(self, Text) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@protected
+function Checkbox:init(props, basalt) end
+
+---Sets the value of the Checked property.
+---@param self Checkbox self
+---@param Checked boolean checkbox is checked
+function Checkbox:setChecked(self, Checked) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Checkbox:render() end
+
+---Gets the value of the Text property.
+---@param self Checkbox self
+---@return string empty Text to display
+function Checkbox:getText(self) end
+
+---Sets the value of the AutoSize property.
+---@param self Checkbox self
+---@param AutoSize boolean Whether to automatically size the checkbox
+function Checkbox:setAutoSize(self, AutoSize) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@return Checkbox self The created instance
+---@protected
+function Checkbox.new() end
+
+---Gets the value of the Checked property.
+---@param self Checkbox self
+---@return boolean Whether checkbox is checked
+function Checkbox:getChecked(self) end
+
+---Sets the value of the CheckedText property.
+---@param self Checkbox self
+---@param CheckedText string when checked
+function Checkbox:setCheckedText(self, CheckedText) end
+
+---Gets the value of the CheckedText property.
+---@param self Checkbox self
+---@return string Text when checked
+function Checkbox:getCheckedText(self) end
+
+---Gets the value of the AutoSize property.
+---@param self Checkbox self
+---@return boolean true Whether to automatically size the checkbox
+function Checkbox:getAutoSize(self) end
+
+---@class TextBox : VisualElement
+---@field lines table Array of text lines
+---@field cursorX number Cursor X position
+---@field cursorColor number Color of the cursor
+---@field editable boolean Whether text can be edited
+---@field cursorY number Cursor Y position (line number)
+---@field scrollY number Vertical scroll offset
+---@field scrollX number Horizontal scroll offset
+---@field syntaxPatterns table Syntax highlighting patterns
+local TextBox = {}
+
+---Sets the value of the CursorColor property.
+---@param self TextBox self
+---@param CursorColor number Color of the cursor
+function TextBox:setCursorColor(self, CursorColor) end
+
+---Gets the value of the Lines property.
+---@param self TextBox self
+---@return table {} Array of text lines
+function TextBox:getLines(self) end
+
+---Gets the value of the CursorX property.
+---@param self TextBox self
+---@return number 1 Cursor X position
+function TextBox:getCursorX(self) end
+
+---Sets the value of the ScrollX property.
+---@param self TextBox self
+---@param ScrollX number Horizontal scroll offset
+function TextBox:setScrollX(self, ScrollX) end
+
+---Sets the value of the CursorY property.
+---@param self TextBox self
+---@param CursorY number Cursor Y position (line number)
+function TextBox:setCursorY(self, CursorY) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean handled Whether the event was handled
+---@protected
+function TextBox:mouse_click(button, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function TextBox:render() end
+
+---Gets the value of the CursorColor property.
+---@param self TextBox self
+---@return number nil Color of the cursor
+function TextBox:getCursorColor(self) end
+
+---Sets the value of the ScrollY property.
+---@param self TextBox self
+---@param ScrollY number Vertical scroll offset
+function TextBox:setScrollY(self, ScrollY) end
+
+---Adds a new syntax highlighting pattern
+---@param pattern string The regex pattern to match
+---@param color colors The color to apply
+---@return TextBox self The TextBox instance
+function TextBox:addSyntaxPattern(pattern, color) end
+
+---Sets the text of the TextBox
+---@param text string The text to set
+---@return TextBox self The TextBox instance
+function TextBox:setText(text) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return TextBox self The initialized instance
+---@protected
+function TextBox:init(props, basalt) end
+
+---Sets the value of the Editable property.
+---@param self TextBox self
+---@param Editable boolean Whether text can be edited
+function TextBox:setEditable(self, Editable) end
+
+---Gets the value of the ScrollX property.
+---@param self TextBox self
+---@return number 0 Horizontal scroll offset
+function TextBox:getScrollX(self) end
+
+---Updates the viewport to keep the cursor in view
+---@return TextBox self The TextBox instance
+function TextBox:updateViewport() end
+
+---Sets the value of the SyntaxPatterns property.
+---@param self TextBox self
+---@param SyntaxPatterns table Syntax highlighting patterns
+function TextBox:setSyntaxPatterns(self, SyntaxPatterns) end
+
+---Gets the text of the TextBox
+---@return string text The text of the TextBox
+function TextBox:getText() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param direction number The scroll direction
+---@param x number The x position of the scroll
+---@param y number The y position of the scroll
+---@return boolean handled Whether the event was handled
+---@protected
+function TextBox:mouse_scroll(direction, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was pressed
+---@return boolean handled Whether the event was handled
+---@protected
+function TextBox:key(key) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param char string The character that was typed
+---@return boolean handled Whether the event was handled
+---@protected
+function TextBox:char(char) end
+
+---Sets the value of the CursorX property.
+---@param self TextBox self
+---@param CursorX number Cursor X position
+function TextBox:setCursorX(self, CursorX) end
+
+---Gets the value of the CursorY property.
+---@param self TextBox self
+---@return number 1 Cursor Y position (line number)
+function TextBox:getCursorY(self) end
+
+---Gets the value of the Editable property.
+---@param self TextBox self
+---@return boolean true Whether text can be edited
+function TextBox:getEditable(self) end
+
+---Sets the value of the Lines property.
+---@param self TextBox self
+---@param Lines table Array of text lines
+function TextBox:setLines(self, Lines) end
+
+---Gets the value of the ScrollY property.
+---@param self TextBox self
+---@return number 0 Vertical scroll offset
+function TextBox:getScrollY(self) end
+
+---Gets the value of the SyntaxPatterns property.
+---@param self TextBox self
+---@return table {} Syntax highlighting patterns
+function TextBox:getSyntaxPatterns(self) end
+
 ---@class Label : VisualElement
----@field autoSize boolean Whether the label should automatically resize its width based on the text content
 ---@field text string The text content to display. Can be a string or a function that returns a string
+---@field autoSize boolean Whether the label should automatically resize its width based on the text content
 local Label = {}
 
 ---Gets the value of the AutoSize property.
@@ -10,23 +1888,9 @@ local Label = {}
 ---@return boolean true Whether the label should automatically resize its width based on the text content
 function Label:getAutoSize(self) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Label:render() end
-
----Sets the value of the AutoSize property.
----@param self Label self
----@param AutoSize boolean Whether the label should automatically resize its width based on the text content
-function Label:setAutoSize(self, AutoSize) end
-
 ---Gets the wrapped lines of the Label
 ---@return table wrappedText The wrapped lines of the Label
 function Label:getWrappedText() end
-
----Sets the value of the Text property.
----@param self Label self
----@param Text string The text content to display. Can be a string or a function that returns a string
-function Label:setText(self, Text) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param props table The properties to initialize the element with
@@ -35,14 +1899,120 @@ function Label:setText(self, Text) end
 ---@protected
 function Label:init(props, basalt) end
 
+---Sets the value of the AutoSize property.
+---@param self Label self
+---@param AutoSize boolean Whether the label should automatically resize its width based on the text content
+function Label:setAutoSize(self, AutoSize) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Label:render() end
+
 ---Gets the value of the Text property.
 ---@param self Label self
 ---@return string Label The text content to display. Can be a string or a function that returns a string
 function Label:getText(self) end
 
+---Sets the value of the Text property.
+---@param self Label self
+---@param Text string The text content to display. Can be a string or a function that returns a string
+function Label:setText(self, Text) end
+
+---@class Button : VisualElement
+---@field text string Button text
+local Button = {}
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@protected
+function Button:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function Button:render() end
+
+---Sets the value of the Text property.
+---@param self Button self
+---@param Text string Button text
+function Button:setText(self, Text) end
+
+---Gets the value of the Text property.
+---@param self Button self
+---@return string Button Button text
+function Button:getText(self) end
+
+---@class ProgressBar : VisualElement
+---@field progressColor color The color used for the filled portion of the progress bar
+---@field direction string The direction of the progress bar ("up", "down", "left", "right")
+---@field progress number Current progress value (0-100)
+---@field showPercentage boolean Whether to show the percentage text in the center
+local ProgressBar = {}
+
+---Sets the value of the ProgressColor property.
+---@param self ProgressBar self
+---@param ProgressColor color The color used for the filled portion of the progress bar
+function ProgressBar:setProgressColor(self, ProgressColor) end
+
+---Gets the value of the Direction property.
+---@param self ProgressBar self
+---@return string right The direction of the progress bar ("up", "down", "left", "right")
+function ProgressBar:getDirection(self) end
+
+---Gets the value of the Progress property.
+---@param self ProgressBar self
+---@return number 0 Current progress value (0-100)
+function ProgressBar:getProgress(self) end
+
+---Sets the value of the Direction property.
+---@param self ProgressBar self
+---@param Direction string The direction of the progress bar ("up", "down", "left", "right")
+function ProgressBar:setDirection(self, Direction) end
+
+---Gets the value of the ShowPercentage property.
+---@param self ProgressBar self
+---@return boolean false Whether to show the percentage text in the center
+function ProgressBar:getShowPercentage(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function ProgressBar:render() end
+
+---Sets the value of the Progress property.
+---@param self ProgressBar self
+---@param Progress number Current progress value (0-100)
+function ProgressBar:setProgress(self, Progress) end
+
+---Gets the value of the ProgressColor property.
+---@param self ProgressBar self
+---@return color lime The color used for the filled portion of the progress bar
+function ProgressBar:getProgressColor(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return ProgressBar self The initialized instance
+---@protected
+function ProgressBar:init(props, basalt) end
+
+---Sets the value of the ShowPercentage property.
+---@param self ProgressBar self
+---@param ShowPercentage boolean Whether to show the percentage text in the center
+function ProgressBar:setShowPercentage(self, ShowPercentage) end
+
 ---@class Menu : List
 ---@field separatorColor color The color used for separator items in the menu
 local Menu = {}
+
+---Sets the value of the SeparatorColor property.
+---@param self Menu self
+---@param SeparatorColor color The color used for separator items in the menu
+function Menu:setSeparatorColor(self, SeparatorColor) end
+
+---Gets the value of the SeparatorColor property.
+---@param self Menu self
+---@return color gray The color used for separator items in the menu
+function Menu:getSeparatorColor(self) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param button number The button that was clicked
@@ -51,23 +2021,6 @@ local Menu = {}
 ---@return boolean Whether the event was handled
 ---@protected
 function Menu:mouse_click(button, x, y) end
-
----Sets the value of the SeparatorColor property.
----@param self Menu self
----@param SeparatorColor color The color used for separator items in the menu
-function Menu:setSeparatorColor(self, SeparatorColor) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Menu self The initialized instance
----@protected
-function Menu:init(props, basalt) end
-
----Gets the value of the SeparatorColor property.
----@param self Menu self
----@return color gray The color used for separator items in the menu
-function Menu:getSeparatorColor(self) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@protected
@@ -78,43 +2031,605 @@ function Menu:render() end
 ---@return Menu self The Menu instance
 function Menu:setItems(items) end
 
----@class Tree : VisualElement
----@field selectedColor color Background color of selected node
----@field nodes table The tree structure containing node objects with {text, children} properties
----@field expandedNodes table Table of nodes that are currently expanded
----@field selectedNode table nil Currently selected node
----@field nodeColor color Color of unselected nodes
----@field scrollOffset number Current vertical scroll position
----@field horizontalOffset number Current horizontal scroll position
-local Tree = {}
-
----Initializes the Tree instance
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param props table The properties to initialize the element with
 ---@param basalt table The basalt instance
----@return Tree self The initialized instance
+---@return Menu self The initialized instance
 ---@protected
-function Tree:init(props, basalt) end
+function Menu:init(props, basalt) end
+
+---@class Render
+local Render = {}
+
+---Adds a dirty rectangle to the buffer
+---@param x number The x position of the rectangle
+---@param y number The y position of the rectangle
+---@param width number The width of the rectangle
+---@param height number The height of the rectangle
+---@return Render 
+function Render:addDirtyRect(x, y, width, height) end
+
+---Sets the cursor position
+---@param x number The x position of the cursor
+---@param y number The y position of the cursor
+---@param blink boolean Whether the cursor should blink
+---@return Render 
+function Render:setCursor(x, y, blink) end
+
+---Blits text to the screen with multiple lines
+---@param x number The x position to blit to
+---@param y number The y position to blit to
+---@param width number The width of the text
+---@param height number The height of the text
+---@param text string The text to blit
+---@param fg colors The foreground color of the text
+---@param bg colors The background color of the text
+---@return Render 
+function Render:multiBlit(x, y, width, height, text, fg, bg) end
+
+---Blits text to the screen with a background color
+---@param x number The x position to blit to
+---@param y number The y position to blit to
+---@param text string The text to blit
+---@param bg colors The background color of the text
+---@return Render 
+function Render:textBg(x, y, text, bg) end
+
+---Merges two rectangles
+---@param target table The target rectangle
+---@param source table The source rectangle
+---@return Render 
+function Render:mergeRects(target, source) end
+
+---Renders the buffer to the screen
+---@return Render 
+function Render:render() end
+
+---Checks if two rectangles overlap
+---@param r1 table The first rectangle
+---@param r2 table The second rectangle
+---@return boolean 
+function Render:rectOverlaps(r1, r2) end
+
+---Clears an area of the screen
+---@param x number The x position of the area
+---@param y number The y position of the area
+---@param width number The width of the area
+---@param height number The height of the area
+---@param bg colors The background color to clear the area with
+---@return Render 
+function Render:clearArea(x, y, width, height, bg) end
+
+---Sets the size of the render
+---@param width number The width of the render
+---@param height number The height of the render
+---@return Render 
+function Render:setSize(width, height) end
+
+---Creates a new Render object
+---@param terminal table The terminal object to render to
+---@return Render 
+function Render.new(terminal) end
+
+---Blits text to the screen
+---@param x number The x position to blit to
+---@param y number The y position to blit to
+---@param text string The text to blit
+---@return Render 
+function Render:text(x, y, text) end
+
+---Gets the size of the render
+---@return number , number
+function Render:getSize() end
+
+---Blits a foreground color to the screen
+---@param x number The x position
+---@param y number The y position
+---@param fg string The foreground color to blit
+---@return Render 
+function Render:fg(x, y, fg) end
+
+---Clears the screen
+---@param bg colors The background color to clear the screen with
+---@return Render 
+function Render:clear(bg) end
+
+---Blits text to the screen
+---@param x number The x position to blit to
+---@param y number The y position to blit to
+---@param text string The text to blit
+---@param fg string The foreground color of the text
+---@param bg string The background color of the text
+---@return Render 
+function Render:blit(x, y, text, fg, bg) end
+
+---Blits a background color to the screen
+---@param x number The x position
+---@param y number The y position
+---@param bg string The background color to blit
+---@return Render 
+function Render:bg(x, y, bg) end
+
+---Blits text to the screen with a foreground color
+---@param x number The x position to blit to
+---@param y number The y position to blit to
+---@param text string The text to blit
+---@param fg colors The foreground color of the text
+---@return Render 
+function Render:textFg(x, y, text, fg) end
+
+---@class VisualElement : BaseElement
+---@field z number The z-index for layering elements
+---@field foreground color The text/foreground color
+---@field background color The background color
+---@field ignoreOffset boolean Whether to ignore the parent's offset
+---@field clicked boolean Whether the element is currently clicked
+---@field focused boolean Whether the element has input focus
+---@field hover boolean Whether the mouse is currently hover over the element (Craftos-PC only)
+---@field x number The horizontal position relative to parent
+---@field height number The height of the element
+---@field visible boolean Whether the element is visible
+---@field backgroundEnabled boolean Whether to render the background
+---@field width number The width of the element
+---@field y number The vertical position relative to parent
+local VisualElement = {}
+
+---Calculates the position of the element relative to its parent
+---@return number x The x position
+---@return number y The y position
+function VisualElement:calculatePosition() end
+
+---Registers a function to handle the onEnter event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnEnter(self, func) end
+
+---Gets the value of the IgnoreOffset property.
+---@param self VisualElement self
+---@return boolean false Whether to ignore the parent's offset
+function VisualElement:getIgnoreOffset(self) end
+
+---Gets the value of the Z property.
+---@param self VisualElement self
+---@return number 1 The z-index for layering elements
+function VisualElement:getZ(self) end
+
+---Gets the value of the Foreground property.
+---@param self VisualElement self
+---@return color white The text/foreground color
+function VisualElement:getForeground(self) end
+
+---Sets the value of the Foreground property.
+---@param self VisualElement self
+---@param Foreground color The text/foreground color
+function VisualElement:setForeground(self, Foreground) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was released
+---@param x number The x position of the release
+---@param y number The y position of the release
+---@return boolean release Whether the element was released on the element
+---@protected
+function VisualElement:mouse_up(button, x, y) end
+
+---Registers a function to handle the onLeave event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnLeave(self, func) end
+
+---Gets the value of the Hover property.
+---@param self VisualElement self
+---@return boolean false Whether the mouse is currently hover over the element (Craftos-PC only)
+function VisualElement:getHover(self) end
+
+---Creates a new Animation Object
+---@return Animation animation The new animation
+function VisualElement:animate() end
+
+---Registers a function to handle the onKey event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnKey(self, func) end
+
+---Sets the value of the Focused property.
+---@param self VisualElement self
+---@param Focused boolean Whether the element has input focus
+function VisualElement:setFocused(self, Focused) end
+
+---Sets the value of the BackgroundEnabled property.
+---@param self VisualElement self
+---@param BackgroundEnabled boolean Whether to render the background
+function VisualElement:setBackgroundEnabled(self, BackgroundEnabled) end
+
+---Registers a function to handle the onDrag event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnDrag(self, func) end
+
+---Gets the value of the BackgroundEnabled property.
+---@param self VisualElement self
+---@return boolean true Whether to render the background
+function VisualElement:getBackgroundEnabled(self) end
+
+---Sets the value of the X property.
+---@param self VisualElement self
+---@param X number The horizontal position relative to parent
+function VisualElement:setX(self, X) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked while dragging
+---@param x number The x position of the drag
+---@param y number The y position of the drag
+---@return boolean drag Whether the element was dragged
+---@protected
+function VisualElement:mouse_drag(button, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param char string The character that was pressed
+---@protected
+function VisualElement:char(char) end
+
+---Gets the value of the Clicked property.
+---@param self VisualElement self
+---@return boolean false Whether the element is currently clicked
+function VisualElement:getClicked(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw
+---@param y number The y position to draw
+---@param width number The width of the area to draw
+---@param height number The height of the area to draw
+---@param text string The text to draw
+---@param fg string The foreground color
+---@param bg string The background color
+---@protected
+function VisualElement:multiBlit(x, y, width, height, text, fg, bg) end
+
+---Sets the value of the Y property.
+---@param self VisualElement self
+---@param Y number The vertical position relative to parent
+function VisualElement:setY(self, Y) end
+
+---This function is used to prioritize the element by moving it to the top of its parent's children. It removes the element from its parent and adds it back, effectively changing its order.
+---@return VisualElement self The VisualElement instance
+function VisualElement:prioritize() end
+
+---Registers a function to handle the onScroll event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnScroll(self, func) end
+
+---Sets the value of the Clicked property.
+---@param self VisualElement self
+---@param Clicked boolean Whether the element is currently clicked
+function VisualElement:setClicked(self, Clicked) end
+
+---Gets the value of the Height property.
+---@param self VisualElement self
+---@return number 1 The height of the element
+function VisualElement:getHeight(self) end
+
+---Registers a function to handle the onChar event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnChar(self, func) end
+
+---Registers a function to handle the onKeyUp event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnKeyUp(self, func) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position of the cursor
+---@param y number The y position of the cursor
+---@param blink boolean Whether the cursor should blink
+---@param color number The color of the cursor
+---@return VisualElement self The VisualElement instance
+---@protected
+function VisualElement:setCursor(x, y, blink, color) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param _ number unknown
+---@param x number The x position of the mouse
+---@param y number The y position of the mouse
+---@return boolean hover Whether the mouse has moved over the element
+---@protected
+function VisualElement:mouse_move(_, x, y) end
+
+---Sets the value of the Z property.
+---@param self VisualElement self
+---@param Z number The z-index for layering elements
+function VisualElement:setZ(self, Z) end
+
+---Gets the value of the Y property.
+---@param self VisualElement self
+---@return number 1 The vertical position relative to parent
+function VisualElement:getY(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw
+---@param y number The y position to draw
+---@param text string The text char to draw
+---@param bg color The background color
+---@protected
+function VisualElement:textBg(x, y, text, bg) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw
+---@param y number The y position to draw
+---@param text string The text char to draw
+---@param fg color The foreground color
+---@protected
+function VisualElement:textFg(x, y, text, fg) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function VisualElement:postRender() end
+
+---Sets the value of the Background property.
+---@param self VisualElement self
+---@param Background color The background color
+function VisualElement:setBackground(self, Background) end
+
+---Registers a function to handle the onClick event.
+---@param button string
+---@param x number
+---@param y number
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnClick(self, func) end
+
+---Registers a function to handle the onBlur event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnBlur(self, func) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was released
+---@protected
+function VisualElement:key_up(key) end
+
+---Checks if the specified coordinates are within the bounds of the element
+---@param x number The x position to check
+---@param y number The y position to check
+---@return boolean isInBounds Whether the coordinates are within the bounds of the element
+function VisualElement:isInBounds(x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@protected
+function VisualElement:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function VisualElement:blur() end
+
+function VisualElement:drawFg() end
+
+---Sets the value of the Height property.
+---@param self VisualElement self
+---@param Height number The height of the element
+function VisualElement:setHeight(self, Height) end
+
+---Sets the value of the Visible property.
+---@param self VisualElement self
+---@param Visible boolean Whether the element is visible
+function VisualElement:setVisible(self, Visible) end
+
+---Registers a function to handle the onRelease event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnRelease(self, func) end
+
+---Registers a function to handle the onMouseUp event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnMouseUp(self, func) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was released
+---@param x number The x position of the release
+---@param y number The y position of the release
+---@protected
+function VisualElement:mouse_release(button, x, y) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param x number The x position to draw
+---@param y number The y position to draw
+---@param text string The text char to draw
+---@param fg string The foreground color
+---@param bg string The background color
+---@protected
+function VisualElement:blit(x, y, text, fg, bg) end
+
+---Sets the value of the IgnoreOffset property.
+---@param self VisualElement self
+---@param IgnoreOffset boolean Whether to ignore the parent's offset
+function VisualElement:setIgnoreOffset(self, IgnoreOffset) end
+
+---Gets the value of the Visible property.
+---@param self VisualElement self
+---@return boolean true Whether the element is visible
+function VisualElement:getVisible(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param direction number The scroll direction
+---@param x number The x position of the scroll
+---@param y number The y position of the scroll
+---@return boolean scroll Whether the element was scrolled
+---@protected
+function VisualElement:mouse_scroll(direction, x, y) end
+
+---Gets the value of the Background property.
+---@param self VisualElement self
+---@return color black The background color
+function VisualElement:getBackground(self) end
+
+---Returns the absolute position of the element or the given coordinates.
+---@return number x The absolute x position
+---@return number y The absolute y position
+function VisualElement:getAbsolutePosition() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function VisualElement:render() end
+
+---Returns the relative position of the element or the given coordinates.
+---@return number x The relative x position
+---@return number y The relative y position
+function VisualElement:getRelativePosition() end
+
+---Registers a function to handle the onFocus event.
+---@param self VisualElement self
+---@param func function The function to be called when the event fires
+function VisualElement:onOnFocus(self, func) end
+
+function VisualElement:drawBg() end
+
+---Gets the value of the Width property.
+---@param self VisualElement self
+---@return number 1 The width of the element
+function VisualElement:getWidth(self) end
+
+---Gets the value of the Focused property.
+---@param self VisualElement self
+---@return boolean false Whether the element has input focus
+function VisualElement:getFocused(self) end
+
+function VisualElement:drawText() end
+
+---Gets the value of the X property.
+---@param self VisualElement self
+---@return number 1 The horizontal position relative to parent
+function VisualElement:getX(self) end
+
+---Sets the value of the Width property.
+---@param self VisualElement self
+---@param Width number The width of the element
+function VisualElement:setWidth(self, Width) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param key number The key that was pressed
+---@protected
+function VisualElement:key(key) end
+
+---Sets the value of the Hover property.
+---@param self VisualElement self
+---@param Hover boolean Whether the mouse is currently hover over the element (Craftos-PC only)
+function VisualElement:setHover(self, Hover) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function VisualElement:focus() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The button that was clicked
+---@param x number The x position of the click
+---@param y number The y position of the click
+---@return boolean clicked Whether the element was clicked
+---@protected
+function VisualElement:mouse_click(button, x, y) end
+
+---@class Benchmark
+local Benchmark = {}
+
+---Clears all custom benchmarks
+function API.clearAll() end
+
+---Starts a custom benchmark
+---@param name string The name of the benchmark
+function API.start(name) end
+
+---Gets statistics for a benchmark
+---@param name string The name of the benchmark
+---@return table ? stats The benchmark statistics or nil
+function API.getStats(name) end
+
+---Clears a specific benchmark
+---@param name string The name of the benchmark to clear
+function API.clear(name) end
+
+---Stops a custom benchmark
+---@param name string The name of the benchmark to stop
+function API.stop(name) end
+
+---@class ErrorHandler
+local ErrorHandler = {}
+
+---Handles an error
+---@param errMsg string The error message
+function errorHandler.error(errMsg) end
+
+---@class Tree : VisualElement
+---@field horizontalOffset number Current horizontal scroll position
+---@field selectedColor color Background color of selected node
+---@field nodes table The tree structure containing node objects with {text, children} properties
+---@field selectedNode table nil Currently selected node
+---@field expandedNodes table Table of nodes that are currently expanded
+---@field nodeColor color Color of unselected nodes
+---@field scrollOffset number Current vertical scroll position
+local Tree = {}
 
 ---Gets the value of the SelectedNode property.
 ---@param self Tree self
 ---@return table ? nil Currently selected node
 function Tree:getSelectedNode(self) end
 
----Sets the value of the SelectedNode property.
----@param self Tree self
----@param SelectedNode table nil Currently selected node
-function Tree:setSelectedNode(self, SelectedNode) end
-
 ---Gets the value of the ExpandedNodes property.
 ---@param self Tree self
 ---@return table {} Table of nodes that are currently expanded
 function Tree:getExpandedNodes(self) end
 
+---Gets the value of the ScrollOffset property.
+---@param self Tree self
+---@return number 0 Current vertical scroll position
+function Tree:getScrollOffset(self) end
+
 ---Gets the value of the Nodes property.
 ---@param self Tree self
 ---@return table {} The tree structure containing node objects with {text, children} properties
 function Tree:getNodes(self) end
+
+---Sets the value of the ExpandedNodes property.
+---@param self Tree self
+---@param ExpandedNodes table Table of nodes that are currently expanded
+function Tree:setExpandedNodes(self, ExpandedNodes) end
+
+---Sets the value of the SelectedNode property.
+---@param self Tree self
+---@param SelectedNode table nil Currently selected node
+function Tree:setSelectedNode(self, SelectedNode) end
+
+---Sets the value of the ScrollOffset property.
+---@param self Tree self
+---@param ScrollOffset number Current vertical scroll position
+function Tree:setScrollOffset(self, ScrollOffset) end
+
+---Gets the value of the NodeColor property.
+---@param self Tree self
+---@return color white Color of unselected nodes
+function Tree:getNodeColor(self) end
+
+---Toggles a node's expanded state
+---@param node table The node to toggle
+---@return Tree self The Tree instance
+function Tree:toggleNode(node) end
+
+---Sets the value of the SelectedColor property.
+---@param self Tree self
+---@param SelectedColor color Background color of selected node
+function Tree:setSelectedColor(self, SelectedColor) end
+
+---Registers a callback for when a node is selected
+---@param callback function The callback function
+---@return Tree self The Tree instance
+function Tree:onSelect(callback) end
+
+---Sets the value of the Nodes property.
+---@param self Tree self
+---@param Nodes table The tree structure containing node objects with {text, children} properties
+function Tree:setNodes(self, Nodes) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@protected
@@ -125,21 +2640,6 @@ function Tree:render() end
 ---@return number 0 Current horizontal scroll position
 function Tree:getHorizontalOffset(self) end
 
----Sets the value of the NodeColor property.
----@param self Tree self
----@param NodeColor color Color of unselected nodes
-function Tree:setNodeColor(self, NodeColor) end
-
----Sets the value of the ScrollOffset property.
----@param self Tree self
----@param ScrollOffset number Current vertical scroll position
-function Tree:setScrollOffset(self, ScrollOffset) end
-
----Expands a node
----@param node table The node to expand
----@return Tree self The Tree instance
-function Tree:expandNode(node) end
-
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param direction number The scroll direction (1 for up, -1 for down)
 ---@param x number The x position of the scroll
@@ -148,30 +2648,10 @@ function Tree:expandNode(node) end
 ---@protected
 function Tree:mouse_scroll(direction, x, y) end
 
----Sets the value of the HorizontalOffset property.
----@param self Tree self
----@param HorizontalOffset number Current horizontal scroll position
-function Tree:setHorizontalOffset(self, HorizontalOffset) end
-
----Sets the value of the SelectedColor property.
----@param self Tree self
----@param SelectedColor color Background color of selected node
-function Tree:setSelectedColor(self, SelectedColor) end
-
 ---Collapses a node
 ---@param node table The node to collapse
 ---@return Tree self The Tree instance
 function Tree:collapseNode(node) end
-
----Sets the value of the Nodes property.
----@param self Tree self
----@param Nodes table The tree structure containing node objects with {text, children} properties
-function Tree:setNodes(self, Nodes) end
-
----Registers a callback for when a node is selected
----@param callback function The callback function
----@return Tree self The Tree instance
-function Tree:onSelect(callback) end
 
 ---Handles mouse click events
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
@@ -182,10 +2662,13 @@ function Tree:onSelect(callback) end
 ---@protected
 function Tree:mouse_click(button, x, y) end
 
----Toggles a node's expanded state
----@param node table The node to toggle
----@return Tree self The Tree instance
-function Tree:toggleNode(node) end
+---Initializes the Tree instance
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return Tree self The initialized instance
+---@protected
+function Tree:init(props, basalt) end
 
 ---Gets the value of the SelectedColor property.
 ---@param self Tree self
@@ -197,432 +2680,95 @@ function Tree:getSelectedColor(self) end
 ---@return number height The height of the tree
 function Tree:getNodeSize() end
 
----Sets the value of the ExpandedNodes property.
+---Sets the value of the HorizontalOffset property.
 ---@param self Tree self
----@param ExpandedNodes table Table of nodes that are currently expanded
-function Tree:setExpandedNodes(self, ExpandedNodes) end
+---@param HorizontalOffset number Current horizontal scroll position
+function Tree:setHorizontalOffset(self, HorizontalOffset) end
 
----Gets the value of the ScrollOffset property.
+---Expands a node
+---@param node table The node to expand
+---@return Tree self The Tree instance
+function Tree:expandNode(node) end
+
+---Sets the value of the NodeColor property.
 ---@param self Tree self
----@return number 0 Current vertical scroll position
-function Tree:getScrollOffset(self) end
+---@param NodeColor color Color of unselected nodes
+function Tree:setNodeColor(self, NodeColor) end
 
----Gets the value of the NodeColor property.
----@param self Tree self
----@return color white Color of unselected nodes
-function Tree:getNodeColor(self) end
-
----@class LineChart : Graph
-local LineChart = {}
+---@class Switch : VisualElement
+---@field checked boolean switch is checked
+local Switch = {}
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@protected
-function LineChart:render() end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return LineChart self The initialized instance
----@protected
-function LineChart:init(props, basalt) end
-
----@class Graph : VisualElement
----@field series table The series of the graph
----@field minValue number The minimum value of the graph
----@field maxValue number The maximum value of the graph
-local Graph = {}
-
----Gets the value of the MaxValue property.
----@param self Graph self
----@return number 100 The maximum value of the graph
-function Graph:getMaxValue(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Graph:render() end
-
----Gets the value of the MinValue property.
----@param self Graph self
----@return number 0 The minimum value of the graph
-function Graph:getMinValue(self) end
-
----Clears all points from a series
----@return Graph self The graph instance
-function Graph:clear() end
-
----Sets the value of the Series property.
----@param self Graph self
----@param Series table The series of the graph
-function Graph:setSeries(self, Series) end
-
----@param name string The name of the series
----@param count number The number of points in the series
----@return Graph self The graph instance
-function Graph:setSeriesPointCount(name, count) end
-
----@param name string The name of the series
----@return table ? series The series
-function Graph:getSeries(name) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Graph self The initialized instance
----@protected
-function Graph:init(props, basalt) end
-
----@param name string The name of the series
----@return Graph self The graph instance
-function Graph:focusSeries(name) end
-
----@param name string The name of the series
----@param visible boolean Whether the series should be visible
----@return Graph self The graph instance
-function Graph:changeSeriesVisibility(name, visible) end
-
----@param name string The name of the series
----@param value number The value of the point
----@return Graph self The graph instance
-function Graph:addPoint(name, value) end
-
----@param name string The name of the series
----@return Graph self The graph instance
-function Graph:removeSeries(name) end
-
----Sets the value of the MaxValue property.
----@param self Graph self
----@param MaxValue number The maximum value of the graph
-function Graph:setMaxValue(self, MaxValue) end
-
----Sets the value of the MinValue property.
----@param self Graph self
----@param MinValue number The minimum value of the graph
-function Graph:setMinValue(self, MinValue) end
-
----@param name string The name of the series
----@param symbol string The symbol of the series
----@param bgCol number The background color of the series
----@param fgCol number The foreground color of the series
----@param pointCount number The number of points in the series
----@return Graph self The graph instance
-function Graph:addSeries(name, symbol, bgCol, fgCol, pointCount) end
-
----@class ErrorHandler
-local ErrorHandler = {}
-
----Handles an error
----@param errMsg string The error message
-function errorHandler.error(errMsg) end
-
----@class Checkbox : VisualElement
----@field checkedText string when checked
----@field text string Text to display
----@field checked boolean checkbox is checked
----@field autoSize boolean Whether to automatically size the checkbox
-local Checkbox = {}
-
----Gets the value of the Checked property.
----@param self Checkbox self
----@return boolean Whether checkbox is checked
-function Checkbox:getChecked(self) end
-
----Sets the value of the Text property.
----@param self Checkbox self
----@param Text string Text to display
-function Checkbox:setText(self, Text) end
-
----Gets the value of the AutoSize property.
----@param self Checkbox self
----@return boolean true Whether to automatically size the checkbox
-function Checkbox:getAutoSize(self) end
-
----Sets the value of the AutoSize property.
----@param self Checkbox self
----@param AutoSize boolean Whether to automatically size the checkbox
-function Checkbox:setAutoSize(self, AutoSize) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean Clicked Whether the event was handled
----@protected
-function Checkbox:mouse_click(button, x, y) end
+function Switch:render() end
 
 ---Sets the value of the Checked property.
----@param self Checkbox self
----@param Checked boolean checkbox is checked
-function Checkbox:setChecked(self, Checked) end
+---@param self Switch self
+---@param Checked boolean switch is checked
+function Switch:setChecked(self, Checked) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@protected
+function Switch:init(props, basalt) end
+
+---Gets the value of the Checked property.
+---@param self Switch self
+---@return boolean Whether switch is checked
+function Switch:getChecked(self) end
+
+---@class Reactive
+local Reactive = {}
+
+---@class BigFont : VisualElement
+---@field text string BigFont text
+---@field fontSize number The font size of the BigFont
+local BigFont = {}
 
 ---Gets the value of the Text property.
----@param self Checkbox self
----@return string empty Text to display
-function Checkbox:getText(self) end
+---@param self BigFont self
+---@return string BigFont BigFont text
+function BigFont:getText(self) end
 
----Gets the value of the CheckedText property.
----@param self Checkbox self
----@return string Text when checked
-function Checkbox:getCheckedText(self) end
+---Sets the value of the Text property.
+---@param self BigFont self
+---@param Text string BigFont text
+function BigFont:setText(self, Text) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@protected
-function Checkbox:init(props, basalt) end
+---Gets the value of the FontSize property.
+---@param self BigFont self
+---@return number 1 The font size of the BigFont
+function BigFont:getFontSize(self) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@return Checkbox self The created instance
----@protected
-function Checkbox.new() end
-
----Sets the value of the CheckedText property.
----@param self Checkbox self
----@param CheckedText string when checked
-function Checkbox:setCheckedText(self, CheckedText) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Checkbox:render() end
-
----@class BaseElement : PropertySystem
----@field eventCallbacks table The event callbacks for the element
----@field id string The unique identifier for the element
----@field name string The name of the element
----@field type string The type identifier of the element
-local BaseElement = {}
-
----Gets the value of the EventCallbacks property.
----@param self BaseElement self
----@return table BaseElement The event callbacks for the element
-function BaseElement:getEventCallbacks(self) end
-
----Observes a property and calls a callback when it changes
----@param property string The property to observe
----@param callback function The callback to call when the property changes
----@return table self The BaseElement instance
-function BaseElement:onChange(property, callback) end
-
----Registers a callback for state changes
----@param self BaseElement The element to watch
----@param stateName string The state to watch
----@param callback function Called with (element, newValue, oldValue)
----@return BaseElement self The element instance
-function BaseElement:onStateChange(self, stateName, callback) end
-
----Gets the value of the Id property.
----@param self BaseElement self
----@return string BaseElement The unique identifier for the element
-function BaseElement:getId(self) end
-
----Enables or disables event listening for a specific event
----@param eventName string The name of the event to listen for
----@return table self The BaseElement instance
-function BaseElement:listenEvent(eventName) end
-
----Binds a property to a state
----@param self BaseElement The element to bind
----@param propertyName string The property to bind
----@param stateName string The state to bind to (optional, uses propertyName if not provided)
----@return BaseElement self The element instance
-function BaseElement:bind(self, propertyName, stateName) end
-
----Logs benchmark statistics for a method
----@param methodName string The name of the method to log
----@return BaseElement self The element instance
-function BaseElement:logBenchmark(methodName) end
-
----Ends profiling a method
----@param methodName string The name of the method to stop profiling
----@return BaseElement self The element instance
-function BaseElement:endProfile(methodName) end
-
----Sets the value of the Type property.
----@param self BaseElement self
----@param Type string The type identifier of the element
-function BaseElement:setType(self, Type) end
-
----Enables benchmarking for a method
----@param methodName string The name of the method to benchmark
----@return BaseElement self The element instance
-function BaseElement:benchmark(methodName) end
-
----Applies the current theme to this element
----@param self BaseElement The element to apply theme to
----@param applyToChildren boolean ? Whether to apply theme to child elements (default: true)
----@return BaseElement self The element instance
-function BaseElement:applyTheme(self, applyToChildren) end
-
----Removes a state change observer
----@param self BaseElement The element to remove observer from
----@param stateName string The state to remove observer from
----@param callback function The callback function to remove
----@return BaseElement self The element instance
-function BaseElement:removeStateChange(self, stateName, callback) end
-
----Starts profiling a method
----@param methodName string The name of the method to profile
----@return BaseElement self The element instance
-function BaseElement:startProfile(methodName) end
-
-function BaseElement:computed() end
-
----Stops benchmarking for a method
----@param methodName string The name of the method to stop benchmarking
----@return BaseElement self The element instance
-function BaseElement:stopBenchmark(methodName) end
-
----Gets benchmark statistics for a method
----@param methodName string The name of the method to get statistics for
----@return table ? stats The benchmark statistics or nil
-function BaseElement:getBenchmarkStats(methodName) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param event string The event to handle
----@return boolean ? handled Whether the event was handled
----@protected
-function BaseElement:dispatchEvent(event) end
-
----Sets the value of the Name property.
----@param self BaseElement self
----@param Name string The name of the element
-function BaseElement:setName(self, Name) end
-
----Enables debugging for this element
----@param self BaseElement The element to debug
----@param level number The debug level
-function BaseElement.debug(self, level) end
+---Sets the value of the FontSize property.
+---@param self BigFont self
+---@param FontSize number The font size of the BigFont
+function BigFont:setFontSize(self, FontSize) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param props table The properties to initialize the element with
 ---@param basalt table The basalt instance
----@return table self The initialized instance
 ---@protected
-function BaseElement:init(props, basalt) end
-
----Registers a new event callback for the element (on class level)
----@param class table The class to register
----@param callbackName string The name of the callback to register
-function BaseElement.registerEventCallback(class, callbackName) end
-
----Gets the value of the Type property.
----@param self BaseElement self
----@return string BaseElement The type identifier of the element
-function BaseElement:getType(self) end
-
----Destroys the element and cleans up all references
-function BaseElement:destroy() end
-
----Dumps debug information for this element
----@param self BaseElement The element to dump debug info for
-function BaseElement.dumpDebug(self) end
-
----Checks if the element is a specific type
----@param type string The type to check for
----@return boolean isType Whether the element is of the specified type
-function BaseElement:isType(type) end
+function BigFont:init(props, basalt) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param event string The event to handle
----@return boolean ? handled Whether the event was handled
 ---@protected
-function BaseElement:handleEvent(event) end
-
----Sets the value of the EventCallbacks property.
----@param self BaseElement self
----@param EventCallbacks table The event callbacks for the element
-function BaseElement:setEventCallbacks(self, EventCallbacks) end
-
----Sets the value of the Id property.
----@param self BaseElement self
----@param Id string The unique identifier for the element
-function BaseElement:setId(self, Id) end
-
----Triggers an event and calls all registered callbacks
----@param event string The event to fire
----@return table self The BaseElement instance
-function BaseElement:fireEvent(event) end
-
----Sets the value of a state
----@param self BaseElement The element to set state for
----@param name string The name of the state
----@param value any The new value for the state
----@return BaseElement self The element instance
-function BaseElement:setState(self, name, value) end
-
----Requests a render update for this element
----@return table self The BaseElement instance
-function BaseElement:updateRender() end
-
----Registers a new event listener for the element (on class level)
----@param class table The class to register
----@param eventName string The name of the event to register
-function BaseElement.defineEvent(class, eventName) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@return table self The BaseElement instance
----@protected
-function BaseElement:postInit() end
-
----Returns the base frame of the element
----@return BaseFrame BaseFrame The base frame of the element
-function BaseElement:getBaseFrame() end
-
----Gets the theme properties for this element
----@param self BaseElement The element to get theme for
----@return table styles The theme properties
-function BaseElement:getTheme(self) end
-
----Registers a callback function for an event
----@param event string The event to register the callback for
----@param callback function The callback function to register
----@return table self The BaseElement instance
-function BaseElement:registerCallback(event, callback) end
-
----Gets the value of the Name property.
----@param self BaseElement self
----@return string BaseElement The name of the element
-function BaseElement:getName(self) end
-
----Gets the value of a state
----@param self BaseElement The element to get state from
----@param name string The name of the state
----@return any value The current state value
-function BaseElement:getState(self, name) end
+function BigFont:render() end
 
 ---@class PropertySystem
 local PropertySystem = {}
-
----Creates a blueprint of an element class with all its properties
----@param elementClass table The element class to create a blueprint from
----@return table blueprint A table containing all property definitions
-function PropertySystem.blueprint(elementClass) end
-
----Removes all observers from a property
----@return table self The PropertySystem
-function PropertySystem:removeAllObservers() end
-
----Creates an element from a blueprint
----@param elementClass table The element class to create from the blueprint
----@param blueprint table The blueprint to create the element from
----@return table element The created element
-function PropertySystem.createFromBlueprint(elementClass, blueprint) end
 
 ---Combines multiple properties into a single getter and setter
 ---@param class table The element class to combine the properties for
 ---@param name string The name of the combined property
 function PropertySystem.combineProperties(class, name) end
 
----Observers a property
----@param name string The name of the property
----@param callback function The callback function to call when the property changes
----@return table self The PropertySystem
-function PropertySystem:observe(name, callback) end
-
----Defines a property for an element class
----@param class table The element class to define the property for
----@param name string The name of the property
----@param config table The configuration of the property
-function PropertySystem.defineProperty(class, name, config) end
+---Creates a blueprint of an element class with all its properties
+---@param elementClass table The element class to create a blueprint from
+---@return table blueprint A table containing all property definitions
+function PropertySystem.blueprint(elementClass) end
 
 ---Gets a property configuration
 ---@param name string The name of the property
@@ -634,11 +2780,19 @@ function PropertySystem:getPropertyConfig(name) end
 ---@return table self The PropertySystem
 function PropertySystem:removeProperty(name) end
 
+---Initializes the PropertySystem IS USED INTERNALLY
+---@return table self The PropertySystem
+function PropertySystem:__init() end
+
 ---Adds a property to the PropertySystem on instance level
 ---@param name string The name of the property
 ---@param config table The configuration of the property
 ---@return table self The PropertySystem
 function PropertySystem:instanceProperty(name, config) end
+
+---Removes all observers from a property
+---@return table self The PropertySystem
+function PropertySystem:removeAllObservers() end
 
 ---Update call for a property IS USED INTERNALLY
 ---@param name string The name of the property
@@ -656,571 +2810,65 @@ function PropertySystem:removeObserver(name, callback) end
 ---@param hook function The hook function to add
 function PropertySystem.addSetterHook(hook) end
 
----Initializes the PropertySystem IS USED INTERNALLY
+---Defines a property for an element class
+---@param class table The element class to define the property for
+---@param name string The name of the property
+---@param config table The configuration of the property
+function PropertySystem.defineProperty(class, name, config) end
+
+---Observers a property
+---@param name string The name of the property
+---@param callback function The callback function to call when the property changes
 ---@return table self The PropertySystem
-function PropertySystem:__init() end
-
----@class Display : VisualElement
-local Display = {}
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@protected
-function Display:init(props, basalt) end
-
----Returns the current window object
----@return table window The current window object
-function Display:getWindow() end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Display:render() end
-
----Writes text to the display at the given position with the given foreground and background colors
----@param x number The x position to write to
----@param y number The y position to write to
----@param text string The text to write
----@return Display self The display instance
-function Display:write(x, y, text) end
-
----@class BaseFrame : Container
----@field term term term.current() The terminal or (monitor) peripheral object to render to
-local BaseFrame = {}
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param char string The character that was pressed
----@protected
-function BaseFrame:char(char) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function BaseFrame:render() end
-
-function BaseFrame:drawBg() end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was released
----@protected
-function BaseFrame:key_up(key) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to render to
----@param y number The y position to render to
----@param text string The text to render
----@param fg string The foreground color
----@param bg string The background color
----@protected
-function BaseFrame:blit(x, y, text, fg, bg) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function BaseFrame:term_resize() end
-
----Sets the cursor position
----@param x number The x position to set the cursor to
----@param y number The y position to set the cursor to
----@param blink boolean Whether the cursor should blink
-function BaseFrame:setCursor(x, y, blink) end
-
----Initializes a new state for this element
----@param self BaseFrame The element to initialize state for
----@param name string The name of the state
----@param default any The default value of the state
----@return BaseFrame self The element instance
-function BaseFrame:initializeState(self, name, default) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to render to
----@param y number The y position to render to
----@param text string The text to render
----@param fg colors The foreground color
----@protected
-function BaseFrame:textFg(x, y, text, fg) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was released
----@param x number The x position of the mouse
----@param y number The y position of the mouse
----@protected
-function BaseFrame:mouse_up(button, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param name string The name of the monitor that was touched
----@param x number The x position of the mouse
----@param y number The y position of the mouse
----@protected
-function BaseFrame:monitor_touch(name, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to render to
----@param y number The y position to render to
----@param text string The text to render
----@param bg colors The background color
----@protected
-function BaseFrame:drawText(x, y, text, bg) end
-
----Toggles the debug log frame
----@param self BaseFrame The frame to toggle debug log for
-function BaseFrame.toggleConsole(self) end
-
----Hides the debug log frame
----@param self BaseFrame The frame to hide debug log for
-function BaseFrame.closeConsole(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to render to
----@param y number The y position to render to
----@param width number The width of the text
----@param height number The height of the text
----@param text string The text to render
----@param fg string The foreground color
----@param bg string The background color
----@protected
-function BaseFrame:multiBlit(x, y, width, height, text, fg, bg) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was pressed
----@protected
-function BaseFrame:key(key) end
-
-function BaseFrame.setup() end
-
----Shows the debug log frame
----@param self BaseFrame The frame to show debug log in
-function BaseFrame.openConsole(self) end
-
----Gets the value of the Term property.
----@param self BaseFrame self
----@return term |peripheral term.current() The terminal or (monitor) peripheral object to render to
-function BaseFrame:getTerm(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return table self The initialized instance
----@protected
-function BaseFrame:init(props, basalt) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to render to
----@param y number The y position to render to
----@param text string The text to render
----@param bg colors The background color
----@protected
-function BaseFrame:textBg(x, y, text, bg) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the mouse
----@param y number The y position of the mouse
----@protected
-function BaseFrame:mouse_click(button, x, y) end
-
----Sets the value of the Term property.
----@param self BaseFrame self
----@param Term term term.current() The terminal or (monitor) peripheral object to render to
-function BaseFrame:setTerm(self, Term) end
-
-function BaseFrame:dispatchEvent() end
-
-function BaseFrame:drawFg() end
-
----@class Animation
-local Animation = {}
-
----Registers a new easing function
----@param name string The name of the easing function
----@param func function The easing function (takes progress 0-1, returns modified progress)
-function Animation.registerEasing(name, func) end
-
----Registers a new animation type
----@param name string The name of the animation
----@param handlers table Table containing start, update and complete handlers
-function Animation.registerAnimation(name, handlers) end
-
----The event handler for the animation (listens to timer events)
----@param event string The event type
----@param timerId number The timer ID
-function Animation:event(event, timerId) end
-
----Registers a callback for the update event
----@param callback function The callback function to register
----@return Animation self The animation instance
-function Animation:onUpdate(callback) end
-
----Creates a new Animation
----@param element VisualElement The element to animate
----@return Animation The new animation
-function Animation.new(element) end
-
----Starts the animation
----@return Animation self The animation instance
-function Animation:start() end
-
----Registers a callback for the complete event
----@param callback function The callback function to register
----@return Animation self The animation instance
-function Animation:onComplete(callback) end
-
----Creates a new sequence
----@return Animation self The animation instance
-function Animation:sequence() end
-
----Registers a callback for the start event
----@param callback function The callback function to register
-function Animation:onStart(callback) end
-
----Adds a new animation to the sequence
----@param type string The type of animation
----@param args table The animation arguments
----@param duration number The duration in seconds
----@param easing string The easing function name
-function Animation:addAnimation(type, args, duration, easing) end
-
----@class Input : VisualElement
----@field text string The current text content of the input
----@field replaceChar string Character to replace the input with (for password fields)
----@field maxLength number nil Maximum length of input text (optional)
----@field viewOffset number The horizontal scroll offset for viewing long text
----@field cursorColor number Color of the cursor
----@field focusedForeground color Foreground color when input is focused
----@field focusedBackground color Background color when input is focused
----@field pattern string nil Regular expression pattern for input validation
----@field placeholder string Text to display when input is empty
----@field cursorPos number The current cursor position in the text
----@field placeholderColor color Color of the placeholder text
-local Input = {}
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Input:render() end
-
----Gets the value of the CursorPos property.
----@param self Input self
----@return number 1 The current cursor position in the text
-function Input:getCursorPos(self) end
-
----Gets the value of the PlaceholderColor property.
----@param self Input self
----@return color gray Color of the placeholder text
-function Input:getPlaceholderColor(self) end
-
----Gets the value of the ViewOffset property.
----@param self Input self
----@return number 0 The horizontal scroll offset for viewing long text
-function Input:getViewOffset(self) end
-
----Updates the input's viewport
----@return Input self The updated instance
-function Input:updateViewport() end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Input:blur() end
-
----Gets the value of the Text property.
----@param self Input self
----@return string - The current text content of the input
-function Input:getText(self) end
-
----Sets the value of the FocusedForeground property.
----@param self Input self
----@param FocusedForeground color Foreground color when input is focused
-function Input:setFocusedForeground(self, FocusedForeground) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Input:focus() end
-
----Gets the value of the FocusedBackground property.
----@param self Input self
----@return color blue Background color when input is focused
-function Input:getFocusedBackground(self) end
-
----Sets the value of the CursorPos property.
----@param self Input self
----@param CursorPos number The current cursor position in the text
-function Input:setCursorPos(self, CursorPos) end
-
----Sets the value of the ReplaceChar property.
----@param self Input self
----@param ReplaceChar string Character to replace the input with (for password fields)
-function Input:setReplaceChar(self, ReplaceChar) end
-
----Sets the value of the PlaceholderColor property.
----@param self Input self
----@param PlaceholderColor color Color of the placeholder text
-function Input:setPlaceholderColor(self, PlaceholderColor) end
-
----Sets the cursor position and color
----@param x number The x position of the cursor
----@param y number The y position of the cursor
----@param blink boolean Whether the cursor should blink
----@param color number The color of the cursor
-function Input:setCursor(x, y, blink, color) end
-
----Gets the value of the FocusedForeground property.
----@param self Input self
----@return color white Foreground color when input is focused
-function Input:getFocusedForeground(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Input:mouse_click(button, x, y) end
-
----Sets the value of the Placeholder property.
----@param self Input self
----@param Placeholder string Text to display when input is empty
-function Input:setPlaceholder(self, Placeholder) end
-
----Gets the value of the MaxLength property.
----@param self Input self
----@return number ? nil Maximum length of input text (optional)
-function Input:getMaxLength(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Input self The initialized instance
----@protected
-function Input:init(props, basalt) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param char string The character that was typed
----@return boolean handled Whether the event was handled
----@protected
-function Input:char(char) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was pressed
----@return boolean handled Whether the event was handled
----@protected
-function Input:key(key) end
-
----Gets the value of the ReplaceChar property.
----@param self Input self
----@return string nil Character to replace the input with (for password fields)
-function Input:getReplaceChar(self) end
-
----Sets the value of the CursorColor property.
----@param self Input self
----@param CursorColor number Color of the cursor
-function Input:setCursorColor(self, CursorColor) end
-
----Gets the value of the Pattern property.
----@param self Input self
----@return string ? nil Regular expression pattern for input validation
-function Input:getPattern(self) end
-
----Sets the value of the MaxLength property.
----@param self Input self
----@param MaxLength number nil Maximum length of input text (optional)
-function Input:setMaxLength(self, MaxLength) end
-
----Sets the value of the FocusedBackground property.
----@param self Input self
----@param FocusedBackground color Background color when input is focused
-function Input:setFocusedBackground(self, FocusedBackground) end
-
----Sets the value of the Pattern property.
----@param self Input self
----@param Pattern string nil Regular expression pattern for input validation
-function Input:setPattern(self, Pattern) end
-
----Gets the value of the CursorColor property.
----@param self Input self
----@return number nil Color of the cursor
-function Input:getCursorColor(self) end
-
----Sets the value of the ViewOffset property.
----@param self Input self
----@param ViewOffset number The horizontal scroll offset for viewing long text
-function Input:setViewOffset(self, ViewOffset) end
-
----Gets the value of the Placeholder property.
----@param self Input self
----@return string ... Text to display when input is empty
-function Input:getPlaceholder(self) end
-
----Sets the value of the Text property.
----@param self Input self
----@param Text string The current text content of the input
-function Input:setText(self, Text) end
-
----@class Log
-local Log = {}
-
----Sends a warning message to the logger.
-function Log.warn() end
-
----Sends an error message to the logger.
-function Log.error() end
-
----Sends a debug message to the logger.
-function Log.debug() end
-
----Sends an info message to the logger.
-function Log.info() end
-
----Sets if the logger should log to a file.
-function Log.setLogToFile() end
-
----Sets if the logger should log
-function Log.setEnabled() end
+function PropertySystem:observe(name, callback) end
+
+---Creates an element from a blueprint
+---@param elementClass table The element class to create from the blueprint
+---@param blueprint table The blueprint to create the element from
+---@return table element The created element
+function PropertySystem.createFromBlueprint(elementClass, blueprint) end
 
 ---@class ScrollBar : VisualElement
----@field step number Step size for scroll operations
----@field dragMultiplier number How fast the ScrollBar moves when dragging
----@field max number Maximum scroll value
----@field attachedElement table nil The element this ScrollBar is attached to
----@field attachedProperty string nil The property being controlled
----@field backgroundSymbol string Symbol used for the ScrollBar background
----@field orientation string Orientation of the ScrollBar ("vertical" or "horizontal")
----@field maxValue number 100 Maximum value or function that returns it
 ---@field min number Minimum scroll value
+---@field attachedElement table nil The element this ScrollBar is attached to
+---@field max number Maximum scroll value
 ---@field symbolBackgroundColor color Background color of the ScrollBar handle
----@field symbol string " Symbol used for the ScrollBar handle
----@field value number Current scroll value
+---@field maxValue number 100 Maximum value or function that returns it
+---@field attachedProperty string nil The property being controlled
+---@field orientation string Orientation of the ScrollBar ("vertical" or "horizontal")
 ---@field minValue number 0 Minimum value or function that returns it
+---@field value number Current scroll value
+---@field dragMultiplier number How fast the ScrollBar moves when dragging
 ---@field handleSize number Size of the ScrollBar handle in characters
+---@field backgroundSymbol string Symbol used for the ScrollBar background
+---@field step number Step size for scroll operations
+---@field symbol string " Symbol used for the ScrollBar handle
 local ScrollBar = {}
-
----Gets the value of the SymbolBackgroundColor property.
----@param self ScrollBar self
----@return color black Background color of the ScrollBar handle
-function ScrollBar:getSymbolBackgroundColor(self) end
-
----Gets the value of the AttachedElement property.
----@param self ScrollBar self
----@return table ? nil The element this ScrollBar is attached to
-function ScrollBar:getAttachedElement(self) end
-
----Sets the value of the HandleSize property.
----@param self ScrollBar self
----@param HandleSize number Size of the ScrollBar handle in characters
-function ScrollBar:setHandleSize(self, HandleSize) end
-
----Sets the value of the Symbol property.
----@param self ScrollBar self
----@param Symbol string " Symbol used for the ScrollBar handle
-function ScrollBar:setSymbol(self, Symbol) end
-
----Gets the value of the Symbol property.
----@param self ScrollBar self
----@return string " " Symbol used for the ScrollBar handle
-function ScrollBar:getSymbol(self) end
-
----Gets the value of the MinValue property.
----@param self ScrollBar self
----@return number |function 0 Minimum value or function that returns it
-function ScrollBar:getMinValue(self) end
-
----Sets the value of the AttachedProperty property.
----@param self ScrollBar self
----@param AttachedProperty string nil The property being controlled
-function ScrollBar:setAttachedProperty(self, AttachedProperty) end
-
----Sets the value of the MinValue property.
----@param self ScrollBar self
----@param MinValue number 0 Minimum value or function that returns it
-function ScrollBar:setMinValue(self, MinValue) end
-
----Gets the value of the DragMultiplier property.
----@param self ScrollBar self
----@return number 1 How fast the ScrollBar moves when dragging
-function ScrollBar:getDragMultiplier(self) end
-
----Sets the value of the MaxValue property.
----@param self ScrollBar self
----@param MaxValue number 100 Maximum value or function that returns it
-function ScrollBar:setMaxValue(self, MaxValue) end
-
----Sets the value of the Value property.
----@param self ScrollBar self
----@param Value number Current scroll value
-function ScrollBar:setValue(self, Value) end
-
----Gets the value of the HandleSize property.
----@param self ScrollBar self
----@return number 2 Size of the ScrollBar handle in characters
-function ScrollBar:getHandleSize(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return ScrollBar self The initialized instance
----@protected
-function ScrollBar:init(props, basalt) end
-
----Sets the value of the AttachedElement property.
----@param self ScrollBar self
----@param AttachedElement table nil The element this ScrollBar is attached to
-function ScrollBar:setAttachedElement(self, AttachedElement) end
 
 ---Gets the value of the Value property.
 ---@param self ScrollBar self
 ---@return number 0 Current scroll value
 function ScrollBar:getValue(self) end
 
+---Sets the value of the AttachedElement property.
+---@param self ScrollBar self
+---@param AttachedElement table nil The element this ScrollBar is attached to
+function ScrollBar:setAttachedElement(self, AttachedElement) end
+
+---Attaches the ScrollBar to an element's property
+---@param element BaseElement The element to attach to
+---@param config table Configuration {property = "propertyName", min = number|function, max = number|function}
+---@return ScrollBar self The ScrollBar instance
+function ScrollBar:attach(element, config) end
+
+---Gets the value of the BackgroundSymbol property.
+---@param self ScrollBar self
+---@return string "\127" Symbol used for the ScrollBar background
+function ScrollBar:getBackgroundSymbol(self) end
+
 ---Updates the attached element's property based on the ScrollBar value
 ---@return ScrollBar self The ScrollBar instance
 function ScrollBar:updateAttachedElement() end
-
----Sets the value of the Max property.
----@param self ScrollBar self
----@param Max number Maximum scroll value
-function ScrollBar:setMax(self, Max) end
-
----Gets the value of the AttachedProperty property.
----@param self ScrollBar self
----@return string ? nil The property being controlled
-function ScrollBar:getAttachedProperty(self) end
-
----Gets the value of the Orientation property.
----@param self ScrollBar self
----@return string vertical Orientation of the ScrollBar ("vertical" or "horizontal")
-function ScrollBar:getOrientation(self) end
-
----Gets the value of the Min property.
----@param self ScrollBar self
----@return number 0 Minimum scroll value
-function ScrollBar:getMin(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The mouse button being dragged
----@param x number The x position of the drag
----@param y number The y position of the drag
----@return boolean Whether the event was handled
----@protected
-function ScrollBar:mouse_drag(button, x, y) end
-
----Sets the value of the DragMultiplier property.
----@param self ScrollBar self
----@param DragMultiplier number How fast the ScrollBar moves when dragging
-function ScrollBar:setDragMultiplier(self, DragMultiplier) end
-
----Sets the value of the Min property.
----@param self ScrollBar self
----@param Min number Minimum scroll value
-function ScrollBar:setMin(self, Min) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param direction number The scroll direction (1 for up, -1 for down)
----@param x number The x position of the scroll
----@param y number The y position of the scroll
----@return boolean Whether the event was handled
----@protected
-function ScrollBar:mouse_scroll(direction, x, y) end
-
----Gets the value of the Max property.
----@param self ScrollBar self
----@return number 100 Maximum scroll value
-function ScrollBar:getMax(self) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param button number The mouse button clicked
@@ -1230,139 +2878,169 @@ function ScrollBar:getMax(self) end
 ---@protected
 function ScrollBar:mouse_click(button, x, y) end
 
+---Sets the value of the DragMultiplier property.
+---@param self ScrollBar self
+---@param DragMultiplier number How fast the ScrollBar moves when dragging
+function ScrollBar:setDragMultiplier(self, DragMultiplier) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return ScrollBar self The initialized instance
+---@protected
+function ScrollBar:init(props, basalt) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param direction number The scroll direction (1 for up, -1 for down)
+---@param x number The x position of the scroll
+---@param y number The y position of the scroll
+---@return boolean Whether the event was handled
+---@protected
+function ScrollBar:mouse_scroll(direction, x, y) end
+
+---Sets the value of the HandleSize property.
+---@param self ScrollBar self
+---@param HandleSize number Size of the ScrollBar handle in characters
+function ScrollBar:setHandleSize(self, HandleSize) end
+
+---Sets the value of the Min property.
+---@param self ScrollBar self
+---@param Min number Minimum scroll value
+function ScrollBar:setMin(self, Min) end
+
+---Sets the value of the MaxValue property.
+---@param self ScrollBar self
+---@param MaxValue number 100 Maximum value or function that returns it
+function ScrollBar:setMaxValue(self, MaxValue) end
+
+---Sets the value of the Max property.
+---@param self ScrollBar self
+---@param Max number Maximum scroll value
+function ScrollBar:setMax(self, Max) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The mouse button being dragged
+---@param x number The x position of the drag
+---@param y number The y position of the drag
+---@return boolean Whether the event was handled
+---@protected
+function ScrollBar:mouse_drag(button, x, y) end
+
+---Sets the value of the Value property.
+---@param self ScrollBar self
+---@param Value number Current scroll value
+function ScrollBar:setValue(self, Value) end
+
 ---Sets the value of the BackgroundSymbol property.
 ---@param self ScrollBar self
 ---@param BackgroundSymbol string Symbol used for the ScrollBar background
 function ScrollBar:setBackgroundSymbol(self, BackgroundSymbol) end
-
----Sets the value of the Orientation property.
----@param self ScrollBar self
----@param Orientation string Orientation of the ScrollBar ("vertical" or "horizontal")
-function ScrollBar:setOrientation(self, Orientation) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function ScrollBar:render() end
-
----Gets the value of the BackgroundSymbol property.
----@param self ScrollBar self
----@return string "\127" Symbol used for the ScrollBar background
-function ScrollBar:getBackgroundSymbol(self) end
 
 ---Gets the value of the MaxValue property.
 ---@param self ScrollBar self
 ---@return number |function 100 Maximum value or function that returns it
 function ScrollBar:getMaxValue(self) end
 
----Sets the value of the Step property.
+---Gets the value of the AttachedProperty property.
 ---@param self ScrollBar self
----@param Step number Step size for scroll operations
-function ScrollBar:setStep(self, Step) end
-
----Sets the value of the SymbolBackgroundColor property.
----@param self ScrollBar self
----@param SymbolBackgroundColor color Background color of the ScrollBar handle
-function ScrollBar:setSymbolBackgroundColor(self, SymbolBackgroundColor) end
-
----Attaches the ScrollBar to an element's property
----@param element BaseElement The element to attach to
----@param config table Configuration {property = "propertyName", min = number|function, max = number|function}
----@return ScrollBar self The ScrollBar instance
-function ScrollBar:attach(element, config) end
+---@return string ? nil The property being controlled
+function ScrollBar:getAttachedProperty(self) end
 
 ---Gets the value of the Step property.
 ---@param self ScrollBar self
 ---@return number 1 Step size for scroll operations
 function ScrollBar:getStep(self) end
 
----@class Program : VisualElement
----@field running boolean Whether the program is running
----@field path string The path to the program
----@field program table The program instance
-local Program = {}
+---Gets the value of the HandleSize property.
+---@param self ScrollBar self
+---@return number 2 Size of the ScrollBar handle in characters
+function ScrollBar:getHandleSize(self) end
 
----Gets the value of the Program property.
----@param self Program self
----@return table nil The program instance
-function Program:getProgram(self) end
+---Gets the value of the Min property.
+---@param self ScrollBar self
+---@return number 0 Minimum scroll value
+function ScrollBar:getMin(self) end
 
----Sets the value of the Program property.
----@param self Program self
----@param Program table The program instance
-function Program:setProgram(self, Program) end
+---Gets the value of the Symbol property.
+---@param self ScrollBar self
+---@return string " " Symbol used for the ScrollBar handle
+function ScrollBar:getSymbol(self) end
 
----Registers a callback for the program's error event, if the function returns false, the program won't stop
----@param fn function The callback function to register
----@return Program self The Program instance
-function Program:onError(fn) end
+---Gets the value of the DragMultiplier property.
+---@param self ScrollBar self
+---@return number 1 How fast the ScrollBar moves when dragging
+function ScrollBar:getDragMultiplier(self) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Program:focus() end
-
----Sends an event to the program
----@param event string The event to send
----@return Program self The Program instance
-function Program:sendEvent(event) end
-
----Sets the value of the Path property.
----@param self Program self
----@param Path string The path to the program
-function Program:setPath(self, Path) end
+---Sets the value of the SymbolBackgroundColor property.
+---@param self ScrollBar self
+---@param SymbolBackgroundColor color Background color of the ScrollBar handle
+function ScrollBar:setSymbolBackgroundColor(self, SymbolBackgroundColor) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@protected
-function Program:render() end
+function ScrollBar:render() end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param event string The event to handle
----@return any result The event result
----@protected
-function Program:dispatchEvent(event) end
+---Gets the value of the Max property.
+---@param self ScrollBar self
+---@return number 100 Maximum scroll value
+function ScrollBar:getMax(self) end
 
----Gets the value of the Path property.
----@param self Program self
----@return string "" The path to the program
-function Program:getPath(self) end
+---Sets the value of the MinValue property.
+---@param self ScrollBar self
+---@param MinValue number 0 Minimum value or function that returns it
+function ScrollBar:setMinValue(self, MinValue) end
 
----Gets the value of the Running property.
----@param self Program self
----@return boolean false Whether the program is running
-function Program:getRunning(self) end
+---Gets the value of the SymbolBackgroundColor property.
+---@param self ScrollBar self
+---@return color black Background color of the ScrollBar handle
+function ScrollBar:getSymbolBackgroundColor(self) end
 
----Sets the value of the Running property.
----@param self Program self
----@param Running boolean Whether the program is running
-function Program:setRunning(self, Running) end
+---Gets the value of the MinValue property.
+---@param self ScrollBar self
+---@return number |function 0 Minimum value or function that returns it
+function ScrollBar:getMinValue(self) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Program self The initialized instance
----@protected
-function Program:init(props, basalt) end
+---Sets the value of the Step property.
+---@param self ScrollBar self
+---@param Step number Step size for scroll operations
+function ScrollBar:setStep(self, Step) end
 
----Executes a program
----@param path string The path to the program
----@return Program self The Program instance
-function Program:execute(path) end
+---Gets the value of the AttachedElement property.
+---@param self ScrollBar self
+---@return table ? nil The element this ScrollBar is attached to
+function ScrollBar:getAttachedElement(self) end
 
----@class BarChart : Graph
-local BarChart = {}
+---Sets the value of the Symbol property.
+---@param self ScrollBar self
+---@param Symbol string " Symbol used for the ScrollBar handle
+function ScrollBar:setSymbol(self, Symbol) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return BarChart self The initialized instance
----@protected
-function BarChart:init(props, basalt) end
+---Gets the value of the Orientation property.
+---@param self ScrollBar self
+---@return string vertical Orientation of the ScrollBar ("vertical" or "horizontal")
+function ScrollBar:getOrientation(self) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function BarChart:render() end
+---Sets the value of the AttachedProperty property.
+---@param self ScrollBar self
+---@param AttachedProperty string nil The property being controlled
+function ScrollBar:setAttachedProperty(self, AttachedProperty) end
+
+---Sets the value of the Orientation property.
+---@param self ScrollBar self
+---@param Orientation string Orientation of the ScrollBar ("vertical" or "horizontal")
+function ScrollBar:setOrientation(self, Orientation) end
 
 ---@class AnimationInstance
 local AnimationInstance = {}
+
+---Updates the animation
+---@param elapsed number The elapsed time in seconds
+---@return boolean Whether the animation is finished
+function AnimationInstance:update(elapsed) end
+
+---Starts the animation
+---@return AnimationInstance self The animation instance
+function AnimationInstance:start() end
 
 ---Creates a new AnimationInstance
 ---@param element VisualElement The element to animate
@@ -1373,938 +3051,370 @@ local AnimationInstance = {}
 ---@return AnimationInstance The new animation instance
 function AnimationInstance.new(element, animType, args, duration, easing) end
 
----Starts the animation
----@return AnimationInstance self The animation instance
-function AnimationInstance:start() end
-
----Updates the animation
----@param elapsed number The elapsed time in seconds
----@return boolean Whether the animation is finished
-function AnimationInstance:update(elapsed) end
-
 ---Gets called when the animation is completed
 function AnimationInstance:complete() end
 
----@class TextBox : VisualElement
----@field cursorY number Cursor Y position (line number)
----@field scrollX number Horizontal scroll offset
----@field scrollY number Vertical scroll offset
----@field cursorColor number Color of the cursor
----@field lines table Array of text lines
----@field editable boolean Whether text can be edited
----@field syntaxPatterns table Syntax highlighting patterns
----@field cursorX number Cursor X position
-local TextBox = {}
+---@class Animation
+local Animation = {}
 
----Sets the value of the Lines property.
----@param self TextBox self
----@param Lines table Array of text lines
-function TextBox:setLines(self, Lines) end
+---Creates a new sequence
+---@return Animation self The animation instance
+function Animation:sequence() end
 
----Gets the value of the Editable property.
----@param self TextBox self
----@return boolean true Whether text can be edited
-function TextBox:getEditable(self) end
+---The event handler for the animation (listens to timer events)
+---@param event string The event type
+---@param timerId number The timer ID
+function Animation:event(event, timerId) end
 
----Sets the value of the CursorColor property.
----@param self TextBox self
----@param CursorColor number Color of the cursor
-function TextBox:setCursorColor(self, CursorColor) end
+---Registers a callback for the complete event
+---@param callback function The callback function to register
+---@return Animation self The animation instance
+function Animation:onComplete(callback) end
 
----Gets the value of the ScrollX property.
----@param self TextBox self
----@return number 0 Horizontal scroll offset
-function TextBox:getScrollX(self) end
+---Registers a new easing function
+---@param name string The name of the easing function
+---@param func function The easing function (takes progress 0-1, returns modified progress)
+function Animation.registerEasing(name, func) end
 
----Sets the value of the CursorY property.
----@param self TextBox self
----@param CursorY number Cursor Y position (line number)
-function TextBox:setCursorY(self, CursorY) end
+---Registers a callback for the start event
+---@param callback function The callback function to register
+function Animation:onStart(callback) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was pressed
----@return boolean handled Whether the event was handled
----@protected
-function TextBox:key(key) end
+---Registers a callback for the update event
+---@param callback function The callback function to register
+---@return Animation self The animation instance
+function Animation:onUpdate(callback) end
 
----Gets the value of the SyntaxPatterns property.
----@param self TextBox self
----@return table {} Syntax highlighting patterns
-function TextBox:getSyntaxPatterns(self) end
+---Starts the animation
+---@return Animation self The animation instance
+function Animation:start() end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param char string The character that was typed
----@return boolean handled Whether the event was handled
----@protected
-function TextBox:char(char) end
+---Adds a new animation to the sequence
+---@param type string The type of animation
+---@param args table The animation arguments
+---@param duration number The duration in seconds
+---@param easing string The easing function name
+function Animation:addAnimation(type, args, duration, easing) end
 
----Sets the text of the TextBox
----@param text string The text to set
----@return TextBox self The TextBox instance
-function TextBox:setText(text) end
+---Creates a new Animation
+---@param element VisualElement The element to animate
+---@return Animation The new animation
+function Animation.new(element) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param direction number The scroll direction
----@param x number The x position of the scroll
----@param y number The y position of the scroll
----@return boolean handled Whether the event was handled
----@protected
-function TextBox:mouse_scroll(direction, x, y) end
+---Registers a new animation type
+---@param name string The name of the animation
+---@param handlers table Table containing start, update and complete handlers
+function Animation.registerAnimation(name, handlers) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function TextBox:render() end
+---@class Log
+local Log = {}
 
----Gets the value of the CursorColor property.
----@param self TextBox self
----@return number nil Color of the cursor
-function TextBox:getCursorColor(self) end
+---Sends a debug message to the logger.
+function Log.debug() end
 
----Gets the text of the TextBox
----@return string text The text of the TextBox
-function TextBox:getText() end
+---Sends an error message to the logger.
+function Log.error() end
 
----Sets the value of the CursorX property.
----@param self TextBox self
----@param CursorX number Cursor X position
-function TextBox:setCursorX(self, CursorX) end
+---Sets if the logger should log to a file.
+function Log.setLogToFile() end
+
+---Sends a warning message to the logger.
+function Log.warn() end
+
+---Sets if the logger should log
+function Log.setEnabled() end
+
+---Sends an info message to the logger.
+function Log.info() end
+
+---@class LineChart : Graph
+local LineChart = {}
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
 ---@protected
-function TextBox:mouse_click(button, x, y) end
-
----Updates the viewport to keep the cursor in view
----@return TextBox self The TextBox instance
-function TextBox:updateViewport() end
-
----Gets the value of the CursorY property.
----@param self TextBox self
----@return number 1 Cursor Y position (line number)
-function TextBox:getCursorY(self) end
-
----Gets the value of the ScrollY property.
----@param self TextBox self
----@return number 0 Vertical scroll offset
-function TextBox:getScrollY(self) end
-
----Adds a new syntax highlighting pattern
----@param pattern string The regex pattern to match
----@param color colors The color to apply
----@return TextBox self The TextBox instance
-function TextBox:addSyntaxPattern(pattern, color) end
-
----Sets the value of the ScrollX property.
----@param self TextBox self
----@param ScrollX number Horizontal scroll offset
-function TextBox:setScrollX(self, ScrollX) end
+function LineChart:render() end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param props table The properties to initialize the element with
 ---@param basalt table The basalt instance
----@return TextBox self The initialized instance
+---@return LineChart self The initialized instance
 ---@protected
-function TextBox:init(props, basalt) end
+function LineChart:init(props, basalt) end
 
----Sets the value of the Editable property.
----@param self TextBox self
----@param Editable boolean Whether text can be edited
-function TextBox:setEditable(self, Editable) end
+---@class BaseElement : PropertySystem
+---@field name string The name of the element
+---@field eventCallbacks table The event callbacks for the element
+---@field type string The type identifier of the element
+---@field id string The unique identifier for the element
+local BaseElement = {}
 
----Gets the value of the CursorX property.
----@param self TextBox self
----@return number 1 Cursor X position
-function TextBox:getCursorX(self) end
-
----Gets the value of the Lines property.
----@param self TextBox self
----@return table {} Array of text lines
-function TextBox:getLines(self) end
-
----Sets the value of the ScrollY property.
----@param self TextBox self
----@param ScrollY number Vertical scroll offset
-function TextBox:setScrollY(self, ScrollY) end
-
----Sets the value of the SyntaxPatterns property.
----@param self TextBox self
----@param SyntaxPatterns table Syntax highlighting patterns
-function TextBox:setSyntaxPatterns(self, SyntaxPatterns) end
-
----@class BigFontText
-local BigFontText = {}
-
----@class Switch : VisualElement
----@field checked boolean switch is checked
-local Switch = {}
-
----Gets the value of the Checked property.
----@param self Switch self
----@return boolean Whether switch is checked
-function Switch:getChecked(self) end
-
----Sets the value of the Checked property.
----@param self Switch self
----@param Checked boolean switch is checked
-function Switch:setChecked(self, Checked) end
+---Logs benchmark statistics for a method
+---@param methodName string The name of the method to log
+---@return BaseElement self The element instance
+function BaseElement:logBenchmark(methodName) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@return table self The BaseElement instance
 ---@protected
-function Switch:render() end
+function BaseElement:postInit() end
+
+---Removes a state change observer
+---@param self BaseElement The element to remove observer from
+---@param stateName string The state to remove observer from
+---@param callback function The callback function to remove
+---@return BaseElement self The element instance
+function BaseElement:removeStateChange(self, stateName, callback) end
+
+---Registers a new event callback for the element (on class level)
+---@param class table The class to register
+---@param callbackName string The name of the callback to register
+function BaseElement.registerEventCallback(class, callbackName) end
+
+---Sets the value of the Name property.
+---@param self BaseElement self
+---@param Name string The name of the element
+function BaseElement:setName(self, Name) end
+
+---Dumps debug information for this element
+---@param self BaseElement The element to dump debug info for
+function BaseElement.dumpDebug(self) end
+
+---Sets the value of the Type property.
+---@param self BaseElement self
+---@param Type string The type identifier of the element
+function BaseElement:setType(self, Type) end
+
+---Binds a property to a state
+---@param self BaseElement The element to bind
+---@param propertyName string The property to bind
+---@param stateName string The state to bind to (optional, uses propertyName if not provided)
+---@return BaseElement self The element instance
+function BaseElement:bind(self, propertyName, stateName) end
+
+---Gets the value of the EventCallbacks property.
+---@param self BaseElement self
+---@return table BaseElement The event callbacks for the element
+function BaseElement:getEventCallbacks(self) end
+
+---Enables or disables event listening for a specific event
+---@param eventName string The name of the event to listen for
+---@return table self The BaseElement instance
+function BaseElement:listenEvent(eventName) end
+
+---Registers a new event listener for the element (on class level)
+---@param class table The class to register
+---@param eventName string The name of the event to register
+function BaseElement.defineEvent(class, eventName) end
+
+---Registers a callback for state changes
+---@param self BaseElement The element to watch
+---@param stateName string The state to watch
+---@param callback function Called with (element, newValue, oldValue)
+---@return BaseElement self The element instance
+function BaseElement:onStateChange(self, stateName, callback) end
+
+---Sets the value of the Id property.
+---@param self BaseElement self
+---@param Id string The unique identifier for the element
+function BaseElement:setId(self, Id) end
+
+---Applies the current theme to this element
+---@param self BaseElement The element to apply theme to
+---@param applyToChildren boolean ? Whether to apply theme to child elements (default: true)
+---@return BaseElement self The element instance
+function BaseElement:applyTheme(self, applyToChildren) end
+
+---Gets the value of the Name property.
+---@param self BaseElement self
+---@return string BaseElement The name of the element
+function BaseElement:getName(self) end
+
+---Gets the theme properties for this element
+---@param self BaseElement The element to get theme for
+---@return table styles The theme properties
+function BaseElement:getTheme(self) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param event string The event to handle
+---@return boolean ? handled Whether the event was handled
+---@protected
+function BaseElement:dispatchEvent(event) end
+
+---Returns the base frame of the element
+---@return BaseFrame BaseFrame The base frame of the element
+function BaseElement:getBaseFrame() end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param event string The event to handle
+---@return boolean ? handled Whether the event was handled
+---@protected
+function BaseElement:handleEvent(event) end
+
+---Sets the value of a state
+---@param self BaseElement The element to set state for
+---@param name string The name of the state
+---@param value any The new value for the state
+---@return BaseElement self The element instance
+function BaseElement:setState(self, name, value) end
+
+---Requests a render update for this element
+---@return table self The BaseElement instance
+function BaseElement:updateRender() end
+
+function BaseElement:computed() end
+
+---Gets the value of the Id property.
+---@param self BaseElement self
+---@return string BaseElement The unique identifier for the element
+function BaseElement:getId(self) end
+
+---Triggers an event and calls all registered callbacks
+---@param event string The event to fire
+---@return table self The BaseElement instance
+function BaseElement:fireEvent(event) end
+
+---Stops benchmarking for a method
+---@param methodName string The name of the method to stop benchmarking
+---@return BaseElement self The element instance
+function BaseElement:stopBenchmark(methodName) end
+
+---Starts profiling a method
+---@param methodName string The name of the method to profile
+---@return BaseElement self The element instance
+function BaseElement:startProfile(methodName) end
+
+---Gets the value of a state
+---@param self BaseElement The element to get state from
+---@param name string The name of the state
+---@return any value The current state value
+function BaseElement:getState(self, name) end
+
+---Checks if the element is a specific type
+---@param type string The type to check for
+---@return boolean isType Whether the element is of the specified type
+function BaseElement:isType(type) end
+
+---Sets the value of the EventCallbacks property.
+---@param self BaseElement self
+---@param EventCallbacks table The event callbacks for the element
+function BaseElement:setEventCallbacks(self, EventCallbacks) end
+
+---Gets the value of the Type property.
+---@param self BaseElement self
+---@return string BaseElement The type identifier of the element
+function BaseElement:getType(self) end
+
+---Registers a callback function for an event
+---@param event string The event to register the callback for
+---@param callback function The callback function to register
+---@return table self The BaseElement instance
+function BaseElement:registerCallback(event, callback) end
+
+---Destroys the element and cleans up all references
+function BaseElement:destroy() end
+
+---Observes a property and calls a callback when it changes
+---@param property string The property to observe
+---@param callback function The callback to call when the property changes
+---@return table self The BaseElement instance
+function BaseElement:onChange(property, callback) end
+
+---Enables benchmarking for a method
+---@param methodName string The name of the method to benchmark
+---@return BaseElement self The element instance
+function BaseElement:benchmark(methodName) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param props table The properties to initialize the element with
 ---@param basalt table The basalt instance
+---@return table self The initialized instance
 ---@protected
-function Switch:init(props, basalt) end
+function BaseElement:init(props, basalt) end
 
----@class ProgressBar : VisualElement
----@field direction string The direction of the progress bar ("up", "down", "left", "right")
----@field progressColor color The color used for the filled portion of the progress bar
----@field progress number Current progress value (0-100)
----@field showPercentage boolean Whether to show the percentage text in the center
-local ProgressBar = {}
+---Ends profiling a method
+---@param methodName string The name of the method to stop profiling
+---@return BaseElement self The element instance
+function BaseElement:endProfile(methodName) end
 
----Sets the value of the Direction property.
----@param self ProgressBar self
----@param Direction string The direction of the progress bar ("up", "down", "left", "right")
-function ProgressBar:setDirection(self, Direction) end
+---Enables debugging for this element
+---@param self BaseElement The element to debug
+---@param level number The debug level
+function BaseElement.debug(self, level) end
 
----Sets the value of the ShowPercentage property.
----@param self ProgressBar self
----@param ShowPercentage boolean Whether to show the percentage text in the center
-function ProgressBar:setShowPercentage(self, ShowPercentage) end
+---Gets benchmark statistics for a method
+---@param methodName string The name of the method to get statistics for
+---@return table ? stats The benchmark statistics or nil
+function BaseElement:getBenchmarkStats(methodName) end
 
----Sets the value of the ProgressColor property.
----@param self ProgressBar self
----@param ProgressColor color The color used for the filled portion of the progress bar
-function ProgressBar:setProgressColor(self, ProgressColor) end
-
----Gets the value of the Direction property.
----@param self ProgressBar self
----@return string right The direction of the progress bar ("up", "down", "left", "right")
-function ProgressBar:getDirection(self) end
-
----Gets the value of the ShowPercentage property.
----@param self ProgressBar self
----@return boolean false Whether to show the percentage text in the center
-function ProgressBar:getShowPercentage(self) end
-
----Gets the value of the ProgressColor property.
----@param self ProgressBar self
----@return color lime The color used for the filled portion of the progress bar
-function ProgressBar:getProgressColor(self) end
+---@class Display : VisualElement
+local Display = {}
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@protected
-function ProgressBar:render() end
+function Display:render() end
 
----Gets the value of the Progress property.
----@param self ProgressBar self
----@return number 0 Current progress value (0-100)
-function ProgressBar:getProgress(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return ProgressBar self The initialized instance
----@protected
-function ProgressBar:init(props, basalt) end
-
----Sets the value of the Progress property.
----@param self ProgressBar self
----@param Progress number Current progress value (0-100)
-function ProgressBar:setProgress(self, Progress) end
-
----@class Flexbox : Container
----@field flexDirection string The direction of the flexbox layout "row" or "column"
----@field flexSpacing number The spacing between flex items
----@field flexJustifyContent string The alignment of flex items along the main axis
----@field flexUpdateLayout boolean Whether to update the layout of the flexbox
----@field flexWrap boolean Whether to wrap flex items onto multiple lines
-local Flexbox = {}
-
----Gets the value of the FlexJustifyContent property.
----@param self Flexbox self
----@return string "flex-start" The alignment of flex items along the main axis
-function Flexbox:getFlexJustifyContent(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Flexbox:render() end
-
----Sets the value of the FlexJustifyContent property.
----@param self Flexbox self
----@param FlexJustifyContent string The alignment of flex items along the main axis
-function Flexbox:setFlexJustifyContent(self, FlexJustifyContent) end
-
----Sets the value of the FlexWrap property.
----@param self Flexbox self
----@param FlexWrap boolean Whether to wrap flex items onto multiple lines
-function Flexbox:setFlexWrap(self, FlexWrap) end
-
----Adds a new line break to the flexbox
----@param self Flexbox The element itself
----@return Flexbox 
-function Flexbox:addLineBreak(self) end
-
----Gets the value of the FlexWrap property.
----@param self Flexbox self
----@return boolean false Whether to wrap flex items onto multiple lines
-function Flexbox:getFlexWrap(self) end
-
----Gets the value of the FlexSpacing property.
----@param self Flexbox self
----@return number 1 The spacing between flex items
-function Flexbox:getFlexSpacing(self) end
-
----Sets the value of the FlexUpdateLayout property.
----@param self Flexbox self
----@param FlexUpdateLayout boolean Whether to update the layout of the flexbox
-function Flexbox:setFlexUpdateLayout(self, FlexUpdateLayout) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Flexbox self The initialized instance
----@protected
-function Flexbox:init(props, basalt) end
-
----Sets the value of the FlexSpacing property.
----@param self Flexbox self
----@param FlexSpacing number The spacing between flex items
-function Flexbox:setFlexSpacing(self, FlexSpacing) end
-
----Adds a child element to the flexbox
----@param element Element The child element to add
----@return Flexbox self The flexbox instance
-function Flexbox:addChild(element) end
-
----Gets the value of the FlexUpdateLayout property.
----@param self Flexbox self
----@return boolean false Whether to update the layout of the flexbox
-function Flexbox:getFlexUpdateLayout(self) end
-
----Gets the value of the FlexDirection property.
----@param self Flexbox self
----@return string "row" The direction of the flexbox layout "row" or "column"
-function Flexbox:getFlexDirection(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param element Element The child element to remove
----@return Flexbox self The flexbox instance
----@protected
-function Flexbox:removeChild(element) end
-
----Sets the value of the FlexDirection property.
----@param self Flexbox self
----@param FlexDirection string The direction of the flexbox layout "row" or "column"
-function Flexbox:setFlexDirection(self, FlexDirection) end
-
----@class VisualElement : BaseElement
----@field visible boolean Whether the element is visible
----@field background color The background color
----@field focused boolean Whether the element has input focus
----@field x number The horizontal position relative to parent
----@field y number The vertical position relative to parent
----@field ignoreOffset boolean Whether to ignore the parent's offset
----@field z number The z-index for layering elements
----@field foreground color The text/foreground color
----@field height number The height of the element
----@field hover boolean Whether the mouse is currently hover over the element (Craftos-PC only)
----@field width number The width of the element
----@field backgroundEnabled boolean Whether to render the background
----@field clicked boolean Whether the element is currently clicked
-local VisualElement = {}
-
----Sets the value of the Clicked property.
----@param self VisualElement self
----@param Clicked boolean Whether the element is currently clicked
-function VisualElement:setClicked(self, Clicked) end
-
----Creates a new Animation Object
----@return Animation animation The new animation
-function VisualElement:animate() end
-
----Gets the value of the IgnoreOffset property.
----@param self VisualElement self
----@return boolean false Whether to ignore the parent's offset
-function VisualElement:getIgnoreOffset(self) end
-
----Registers a function to handle the onEnter event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnEnter(self, func) end
-
----Registers a function to handle the onLeave event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnLeave(self, func) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw
----@param y number The y position to draw
----@param width number The width of the area to draw
----@param height number The height of the area to draw
----@param text string The text to draw
----@param fg string The foreground color
----@param bg string The background color
----@protected
-function VisualElement:multiBlit(x, y, width, height, text, fg, bg) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked while dragging
----@param x number The x position of the drag
----@param y number The y position of the drag
----@return boolean drag Whether the element was dragged
----@protected
-function VisualElement:mouse_drag(button, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function VisualElement:postRender() end
-
----Gets the value of the Foreground property.
----@param self VisualElement self
----@return color white The text/foreground color
-function VisualElement:getForeground(self) end
-
-function VisualElement:drawBg() end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was released
----@param x number The x position of the release
----@param y number The y position of the release
----@protected
-function VisualElement:mouse_release(button, x, y) end
-
----Returns the relative position of the element or the given coordinates.
----@return number x The relative x position
----@return number y The relative y position
-function VisualElement:getRelativePosition() end
-
----This function is used to prioritize the element by moving it to the top of its parent's children. It removes the element from its parent and adds it back, effectively changing its order.
----@return VisualElement self The VisualElement instance
-function VisualElement:prioritize() end
-
----Sets the value of the BackgroundEnabled property.
----@param self VisualElement self
----@param BackgroundEnabled boolean Whether to render the background
-function VisualElement:setBackgroundEnabled(self, BackgroundEnabled) end
-
-function VisualElement:drawFg() end
-
----Registers a function to handle the onMouseUp event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnMouseUp(self, func) end
-
----Sets the value of the Y property.
----@param self VisualElement self
----@param Y number The vertical position relative to parent
-function VisualElement:setY(self, Y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw
----@param y number The y position to draw
----@param text string The text char to draw
----@param fg string The foreground color
----@param bg string The background color
----@protected
-function VisualElement:blit(x, y, text, fg, bg) end
-
----Sets the value of the Height property.
----@param self VisualElement self
----@param Height number The height of the element
-function VisualElement:setHeight(self, Height) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw
----@param y number The y position to draw
----@param text string The text char to draw
----@param bg color The background color
----@protected
-function VisualElement:textBg(x, y, text, bg) end
-
----Gets the value of the Height property.
----@param self VisualElement self
----@return number 1 The height of the element
-function VisualElement:getHeight(self) end
-
----Registers a function to handle the onBlur event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnBlur(self, func) end
-
----Registers a function to handle the onKeyUp event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnKeyUp(self, func) end
-
----Gets the value of the Z property.
----@param self VisualElement self
----@return number 1 The z-index for layering elements
-function VisualElement:getZ(self) end
-
----Registers a function to handle the onDrag event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnDrag(self, func) end
+---Returns the current window object
+---@return table window The current window object
+function Display:getWindow() end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
 ---@param props table The properties to initialize the element with
 ---@param basalt table The basalt instance
 ---@protected
-function VisualElement:init(props, basalt) end
-
----Registers a function to handle the onFocus event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnFocus(self, func) end
-
----Gets the value of the Y property.
----@param self VisualElement self
----@return number 1 The vertical position relative to parent
-function VisualElement:getY(self) end
-
----Gets the value of the Clicked property.
----@param self VisualElement self
----@return boolean false Whether the element is currently clicked
-function VisualElement:getClicked(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param _ number unknown
----@param x number The x position of the mouse
----@param y number The y position of the mouse
----@return boolean hover Whether the mouse has moved over the element
----@protected
-function VisualElement:mouse_move(_, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was pressed
----@protected
-function VisualElement:key(key) end
-
----Sets the value of the Foreground property.
----@param self VisualElement self
----@param Foreground color The text/foreground color
-function VisualElement:setForeground(self, Foreground) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function VisualElement:focus() end
-
-function VisualElement:drawText() end
-
----Registers a function to handle the onRelease event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnRelease(self, func) end
-
----Sets the value of the Z property.
----@param self VisualElement self
----@param Z number The z-index for layering elements
-function VisualElement:setZ(self, Z) end
-
----Sets the value of the Background property.
----@param self VisualElement self
----@param Background color The background color
-function VisualElement:setBackground(self, Background) end
-
----Registers a function to handle the onScroll event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnScroll(self, func) end
-
----Gets the value of the BackgroundEnabled property.
----@param self VisualElement self
----@return boolean true Whether to render the background
-function VisualElement:getBackgroundEnabled(self) end
-
----Sets the value of the Hover property.
----@param self VisualElement self
----@param Hover boolean Whether the mouse is currently hover over the element (Craftos-PC only)
-function VisualElement:setHover(self, Hover) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param char string The character that was pressed
----@protected
-function VisualElement:char(char) end
-
----Gets the value of the Visible property.
----@param self VisualElement self
----@return boolean true Whether the element is visible
-function VisualElement:getVisible(self) end
-
----Gets the value of the Focused property.
----@param self VisualElement self
----@return boolean false Whether the element has input focus
-function VisualElement:getFocused(self) end
-
----Registers a function to handle the onKey event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnKey(self, func) end
-
----Sets the value of the X property.
----@param self VisualElement self
----@param X number The horizontal position relative to parent
-function VisualElement:setX(self, X) end
-
----Registers a function to handle the onChar event.
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnChar(self, func) end
-
----Gets the value of the Width property.
----@param self VisualElement self
----@return number 1 The width of the element
-function VisualElement:getWidth(self) end
-
----Sets the value of the Visible property.
----@param self VisualElement self
----@param Visible boolean Whether the element is visible
-function VisualElement:setVisible(self, Visible) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function VisualElement:blur() end
-
----Checks if the specified coordinates are within the bounds of the element
----@param x number The x position to check
----@param y number The y position to check
----@return boolean isInBounds Whether the coordinates are within the bounds of the element
-function VisualElement:isInBounds(x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param direction number The scroll direction
----@param x number The x position of the scroll
----@param y number The y position of the scroll
----@return boolean scroll Whether the element was scrolled
----@protected
-function VisualElement:mouse_scroll(direction, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function VisualElement:render() end
-
----Gets the value of the X property.
----@param self VisualElement self
----@return number 1 The horizontal position relative to parent
-function VisualElement:getX(self) end
-
----Gets the value of the Hover property.
----@param self VisualElement self
----@return boolean false Whether the mouse is currently hover over the element (Craftos-PC only)
-function VisualElement:getHover(self) end
-
----Gets the value of the Background property.
----@param self VisualElement self
----@return color black The background color
-function VisualElement:getBackground(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean clicked Whether the element was clicked
----@protected
-function VisualElement:mouse_click(button, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was released
----@protected
-function VisualElement:key_up(key) end
-
----Sets the value of the Width property.
----@param self VisualElement self
----@param Width number The width of the element
-function VisualElement:setWidth(self, Width) end
-
----Sets the value of the Focused property.
----@param self VisualElement self
----@param Focused boolean Whether the element has input focus
-function VisualElement:setFocused(self, Focused) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was released
----@param x number The x position of the release
----@param y number The y position of the release
----@return boolean release Whether the element was released on the element
----@protected
-function VisualElement:mouse_up(button, x, y) end
-
----Calculates the position of the element relative to its parent
----@return number x The x position
----@return number y The y position
-function VisualElement:calculatePosition() end
-
----Returns the absolute position of the element or the given coordinates.
----@return number x The absolute x position
----@return number y The absolute y position
-function VisualElement:getAbsolutePosition() end
-
----Sets the value of the IgnoreOffset property.
----@param self VisualElement self
----@param IgnoreOffset boolean Whether to ignore the parent's offset
-function VisualElement:setIgnoreOffset(self, IgnoreOffset) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position of the cursor
----@param y number The y position of the cursor
----@param blink boolean Whether the cursor should blink
----@param color number The color of the cursor
----@return VisualElement self The VisualElement instance
----@protected
-function VisualElement:setCursor(x, y, blink, color) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw
----@param y number The y position to draw
----@param text string The text char to draw
----@param fg color The foreground color
----@protected
-function VisualElement:textFg(x, y, text, fg) end
-
----Registers a function to handle the onClick event.
----@param button string
----@param x number
----@param y number
----@param self VisualElement self
----@param func function The function to be called when the event fires
-function VisualElement:onOnClick(self, func) end
-
----@class Render
-local Render = {}
-
----Blits a background color to the screen
----@param x number The x position
----@param y number The y position
----@param bg string The background color to blit
----@return Render 
-function Render:bg(x, y, bg) end
-
----Blits text to the screen with multiple lines
----@param x number The x position to blit to
----@param y number The y position to blit to
----@param width number The width of the text
----@param height number The height of the text
----@param text string The text to blit
----@param fg colors The foreground color of the text
----@param bg colors The background color of the text
----@return Render 
-function Render:multiBlit(x, y, width, height, text, fg, bg) end
-
----Blits text to the screen
----@param x number The x position to blit to
----@param y number The y position to blit to
----@param text string The text to blit
----@return Render 
-function Render:text(x, y, text) end
-
----Renders the buffer to the screen
----@return Render 
-function Render:render() end
-
----Blits a foreground color to the screen
----@param x number The x position
----@param y number The y position
----@param fg string The foreground color to blit
----@return Render 
-function Render:fg(x, y, fg) end
-
----Blits text to the screen with a background color
----@param x number The x position to blit to
----@param y number The y position to blit to
----@param text string The text to blit
----@param bg colors The background color of the text
----@return Render 
-function Render:textBg(x, y, text, bg) end
-
----Checks if two rectangles overlap
----@param r1 table The first rectangle
----@param r2 table The second rectangle
----@return boolean 
-function Render:rectOverlaps(r1, r2) end
-
----Creates a new Render object
----@param terminal table The terminal object to render to
----@return Render 
-function Render.new(terminal) end
-
----Clears the screen
----@param bg colors The background color to clear the screen with
----@return Render 
-function Render:clear(bg) end
-
----Blits text to the screen with a foreground color
----@param x number The x position to blit to
----@param y number The y position to blit to
----@param text string The text to blit
----@param fg colors The foreground color of the text
----@return Render 
-function Render:textFg(x, y, text, fg) end
-
----Sets the cursor position
----@param x number The x position of the cursor
----@param y number The y position of the cursor
----@param blink boolean Whether the cursor should blink
----@return Render 
-function Render:setCursor(x, y, blink) end
-
----Adds a dirty rectangle to the buffer
----@param x number The x position of the rectangle
----@param y number The y position of the rectangle
----@param width number The width of the rectangle
----@param height number The height of the rectangle
----@return Render 
-function Render:addDirtyRect(x, y, width, height) end
-
----Sets the size of the render
----@param width number The width of the render
----@param height number The height of the render
----@return Render 
-function Render:setSize(width, height) end
-
----Gets the size of the render
----@return number , number
-function Render:getSize() end
-
----Clears an area of the screen
----@param x number The x position of the area
----@param y number The y position of the area
----@param width number The width of the area
----@param height number The height of the area
----@param bg colors The background color to clear the area with
----@return Render 
-function Render:clearArea(x, y, width, height, bg) end
-
----Blits text to the screen
----@param x number The x position to blit to
----@param y number The y position to blit to
----@param text string The text to blit
----@param fg string The foreground color of the text
----@param bg string The background color of the text
----@return Render 
-function Render:blit(x, y, text, fg, bg) end
-
----Merges two rectangles
----@param target table The target rectangle
----@param source table The source rectangle
----@return Render 
-function Render:mergeRects(target, source) end
-
----@class BigFont : VisualElement
----@field fontSize number The font size of the BigFont
----@field text string BigFont text
-local BigFont = {}
-
----Gets the value of the Text property.
----@param self BigFont self
----@return string BigFont BigFont text
-function BigFont:getText(self) end
-
----Gets the value of the FontSize property.
----@param self BigFont self
----@return number 1 The font size of the BigFont
-function BigFont:getFontSize(self) end
-
----Sets the value of the Text property.
----@param self BigFont self
----@param Text string BigFont text
-function BigFont:setText(self, Text) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@protected
-function BigFont:init(props, basalt) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function BigFont:render() end
-
----Sets the value of the FontSize property.
----@param self BigFont self
----@param FontSize number The font size of the BigFont
-function BigFont:setFontSize(self, FontSize) end
+function Display:init(props, basalt) end
+
+---Writes text to the display at the given position with the given foreground and background colors
+---@param x number The x position to write to
+---@param y number The y position to write to
+---@param text string The text to write
+---@return Display self The display instance
+function Display:write(x, y, text) end
 
 ---@class List : VisualElement
+---@field selectedBackground color Background color for selected items
 ---@field multiSelection boolean Whether multiple items can be selected at once
 ---@field selectable boolean Whether items in the list can be selected
 ---@field selectedForeground color Text color for selected items
----@field selectedBackground color Background color for selected items
----@field items table List of items to display. Items can be tables with properties including selected state
 ---@field offset number Current scroll offset for viewing long lists
+---@field items table List of items to display. Items can be tables with properties including selected state
 local List = {}
-
----Gets the value of the Offset property.
----@param self List self
----@return number 0 Current scroll offset for viewing long lists
-function List:getOffset(self) end
-
----Gets the value of the MultiSelection property.
----@param self List self
----@return boolean false Whether multiple items can be selected at once
-function List:getMultiSelection(self) end
-
----Sets the value of the SelectedForeground property.
----@param self List self
----@param SelectedForeground color Text color for selected items
-function List:setSelectedForeground(self, SelectedForeground) end
-
----Scrolls the list to the bottom
----@return List self The List instance
-function List:scrollToBottom() end
-
----Adds an item to the list
----@param text string |table The item to add (string or item table)
----@return List self The List instance
-function List:addItem(text) end
-
----Sets the value of the Offset property.
----@param self List self
----@param Offset number Current scroll offset for viewing long lists
-function List:setOffset(self, Offset) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function List:render() end
 
 ---Gets the value of the Items property.
 ---@param self List self
 ---@return table {} List of items to display. Items can be tables with properties including selected state
 function List:getItems(self) end
 
----Sets the value of the Items property.
----@param self List self
----@param Items table List of items to display. Items can be tables with properties including selected state
-function List:setItems(self, Items) end
-
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The mouse button that was clicked
----@param x number The x-coordinate of the click
----@param y number The y-coordinate of the click
----@return boolean Whether the event was handled
+---@param props table The properties to initialize the element with
+---@param basalt table The basalt instance
+---@return List self The initialized instance
 ---@protected
-function List:mouse_click(button, x, y) end
-
----Gets the currently selected items
----@return table selected List of selected items
-function List:getSelectedItems() end
+function List:init(props, basalt) end
 
 ---Removes an item from the list
 ---@param index number The index of the item to remove
 ---@return List self The List instance
 function List:removeItem(index) end
 
----Registers a callback for the select event
----@param callback function The callback function to register
+---Gets the value of the SelectedForeground property.
+---@param self List self
+---@return color white Text color for selected items
+function List:getSelectedForeground(self) end
+
+---Gets the value of the Selectable property.
+---@param self List self
+---@return boolean true Whether items in the list can be selected
+function List:getSelectable(self) end
+
+---Adds an item to the list
+---@param text string |table The item to add (string or item table)
 ---@return List self The List instance
-function List:onSelect(callback) end
+function List:addItem(text) end
+
+---Sets the value of the Selectable property.
+---@param self List self
+---@param Selectable boolean Whether items in the list can be selected
+function List:setSelectable(self, Selectable) end
 
 ---Registers a function to handle the onSelect event.
 ---@param index number
@@ -2313,35 +3423,19 @@ function List:onSelect(callback) end
 ---@param func function The function to be called when the event fires
 function List:onOnSelect(self, func) end
 
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param direction number The direction of the scroll (1 for down, -1 for up)
----@param x number The x-coordinate of the scroll
----@param y number The y-coordinate of the scroll
----@return boolean Whether the event was handled
----@protected
-function List:mouse_scroll(direction, x, y) end
-
----Gets first selected item
----@return table ? selected The first item
-function List:getSelectedItem() end
-
----Scrolls the list to the top
----@return List self The List instance
-function List:scrollToTop() end
+---Gets the value of the SelectedBackground property.
+---@param self List self
+---@return color blue Background color for selected items
+function List:getSelectedBackground(self) end
 
 ---Clears all items from the list
 ---@return List self The List instance
 function List:clear() end
 
----Sets the value of the Selectable property.
+---Sets the value of the Items property.
 ---@param self List self
----@param Selectable boolean Whether items in the list can be selected
-function List:setSelectable(self, Selectable) end
-
----Gets the value of the Selectable property.
----@param self List self
----@return boolean true Whether items in the list can be selected
-function List:getSelectable(self) end
+---@param Items table List of items to display. Items can be tables with properties including selected state
+function List:setItems(self, Items) end
 
 ---Sets the value of the MultiSelection property.
 ---@param self List self
@@ -2353,37 +3447,66 @@ function List:setMultiSelection(self, MultiSelection) end
 ---@param SelectedBackground color Background color for selected items
 function List:setSelectedBackground(self, SelectedBackground) end
 
----Gets the value of the SelectedBackground property.
----@param self List self
----@return color blue Background color for selected items
-function List:getSelectedBackground(self) end
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@protected
+function List:render() end
 
----Gets the value of the SelectedForeground property.
+---Scrolls the list to the top
+---@return List self The List instance
+function List:scrollToTop() end
+
+---Gets the currently selected items
+---@return table selected List of selected items
+function List:getSelectedItems() end
+
+---Sets the value of the Offset property.
 ---@param self List self
----@return color white Text color for selected items
-function List:getSelectedForeground(self) end
+---@param Offset number Current scroll offset for viewing long lists
+function List:setOffset(self, Offset) end
+
+---Registers a callback for the select event
+---@param callback function The callback function to register
+---@return List self The List instance
+function List:onSelect(callback) end
 
 ---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return List self The initialized instance
+---@param direction number The direction of the scroll (1 for down, -1 for up)
+---@param x number The x-coordinate of the scroll
+---@param y number The y-coordinate of the scroll
+---@return boolean Whether the event was handled
 ---@protected
-function List:init(props, basalt) end
+function List:mouse_scroll(direction, x, y) end
 
----@class ThemeAPI
-local ThemeAPI = {}
+---Scrolls the list to the bottom
+---@return List self The List instance
+function List:scrollToBottom() end
 
----Gets the current theme configuration
----@return table theme The current theme configuration
-function ThemeAPI.getTheme() end
+---Gets first selected item
+---@return table ? selected The first item
+function List:getSelectedItem() end
 
----Sets the current theme
----@param newTheme table The theme configuration to set
-function ThemeAPI.setTheme(newTheme) end
+---Gets the value of the MultiSelection property.
+---@param self List self
+---@return boolean false Whether multiple items can be selected at once
+function List:getMultiSelection(self) end
 
----Loads a theme from a JSON file
----@param path string Path to the theme JSON file
-function ThemeAPI.loadTheme(path) end
+---Sets the value of the SelectedForeground property.
+---@param self List self
+---@param SelectedForeground color Text color for selected items
+function List:setSelectedForeground(self, SelectedForeground) end
+
+---This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
+---@param button number The mouse button that was clicked
+---@param x number The x-coordinate of the click
+---@param y number The y-coordinate of the click
+---@return boolean Whether the event was handled
+---@protected
+function List:mouse_click(button, x, y) end
+
+---Gets the value of the Offset property.
+---@param self List self
+---@return number 0 Current scroll offset for viewing long lists
+function List:getOffset(self) end
 
 ---@class ElementManager
 local ElementManager = {}
@@ -2393,11 +3516,6 @@ local ElementManager = {}
 ---@return table API The API
 function ElementManager.getAPI(name) end
 
----Gets an element by name. If the element is not loaded, it will try to load it first.
----@param name string The name of the element to get
----@return table Element The element class
-function ElementManager.getElement(name) end
-
 ---Gets a list of all elements
 ---@return table ElementList A list of all elements
 function ElementManager.getElementList() end
@@ -2406,1126 +3524,8 @@ function ElementManager.getElementList() end
 ---@param name string The name of the element to load
 function ElementManager.loadElement(name) end
 
----@class Image : VisualElement
----@field bimg table The bimg image data
----@field autoResize boolean Whether to automatically resize the image when content exceeds bounds
----@field offsetY number Vertical offset for viewing larger images
----@field currentFrame number Current animation frame
----@field offsetX number Horizontal offset for viewing larger images
-local Image = {}
-
----Sets the foreground color at the specified position
----@param x number The x position
----@param y number The y position
----@param pattern string The foreground color pattern
----@return Image self The Image instance
-function Image:setFg(x, y, pattern) end
-
----Gets the value of the OffsetX property.
----@param self Image self
----@return number 0 Horizontal offset for viewing larger images
-function Image:getOffsetX(self) end
-
----Sets the value of the Bimg property.
----@param self Image self
----@param Bimg table The bimg image data
-function Image:setBimg(self, Bimg) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Image self The initialized instance
----@protected
-function Image:init(props, basalt) end
-
----Gets the value of the Bimg property.
----@param self Image self
----@return table {} The bimg image data
-function Image:getBimg(self) end
-
----Sets the pixel at the specified position
----@param x number The x position
----@param y number The y position
----@param char string The character to set
----@param fg string The foreground color pattern
----@param bg string The background color pattern
----@return Image self The Image instance
-function Image:setPixel(x, y, char, fg, bg) end
-
----Sets the metadata of the image
----@param key string The key of the metadata to set
----@param value string The value of the metadata to set
----@return Image self The Image instance
-function Image:setMetadata(key, value) end
-
----Adds a new frame to the image
----@return Image self The Image instance
-function Image:addFrame() end
-
----Gets the text at the specified position
----@param x number The x position
----@param y number The y position
----@param length number The length of the text to get
----@return string text The text at the specified position
-function Image:getText(x, y, length) end
-
----Gets pixel information at position
----@param x number X position
----@param y number Y position
----@return number ? fg Foreground color
----@return number ? bg Background color
----@return string ? char Character at position
-function Image:getPixelData(x, y) end
-
----Sets the background color at the specified position
----@param x number The x position
----@param y number The y position
----@param pattern string The background color pattern
----@return Image self The Image instance
-function Image:setBg(x, y, pattern) end
-
----Sets the value of the CurrentFrame property.
----@param self Image self
----@param CurrentFrame number Current animation frame
-function Image:setCurrentFrame(self, CurrentFrame) end
-
----Gets the value of the AutoResize property.
----@param self Image self
----@return boolean false Whether to automatically resize the image when content exceeds bounds
-function Image:getAutoResize(self) end
-
----Gets the size of the image
----@return number width The width of the image
----@return number height The height of the image
-function Image:getImageSize() end
-
----Updates the specified frame with the provided data
----@param frameIndex number The index of the frame to update
----@param frame table The new frame data
----@return Image self The Image instance
-function Image:updateFrame(frameIndex, frame) end
-
----Gets the background color at the specified position
----@param x number The x position
----@param y number The y position
----@param length number The length of the background color pattern to get
----@return string bg The background color pattern
-function Image:getBg(x, y, length) end
-
----Gets the metadata of the image
----@return table metadata The metadata of the image
-function Image:getMetadata() end
-
----Advances to the next frame in the animation
----@return Image self The Image instance
-function Image:nextFrame() end
-
----Gets the specified frame
----@param frameIndex number The index of the frame to get
----@return table frame The frame data
-function Image:getFrame(frameIndex) end
-
----Sets the value of the OffsetY property.
----@param self Image self
----@param OffsetY number Vertical offset for viewing larger images
-function Image:setOffsetY(self, OffsetY) end
-
----Gets the foreground color at the specified position
----@param x number The x position
----@param y number The y position
----@param length number The length of the foreground color pattern to get
----@return string fg The foreground color pattern
-function Image:getFg(x, y, length) end
-
----Sets the value of the AutoResize property.
----@param self Image self
----@param AutoResize boolean Whether to automatically resize the image when content exceeds bounds
-function Image:setAutoResize(self, AutoResize) end
-
----Sets the value of the OffsetX property.
----@param self Image self
----@param OffsetX number Horizontal offset for viewing larger images
-function Image:setOffsetX(self, OffsetX) end
-
----Gets the value of the CurrentFrame property.
----@param self Image self
----@return number 1 Current animation frame
-function Image:getCurrentFrame(self) end
-
----Gets the value of the OffsetY property.
----@param self Image self
----@return number 0 Vertical offset for viewing larger images
-function Image:getOffsetY(self) end
-
----Resizes the image to the specified width and height
----@param width number The new width of the image
----@param height number The new height of the image
----@return Image self The Image instance
-function Image:resizeImage(width, height) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Image:render() end
-
----Sets the text at the specified position
----@param x number The x position
----@param y number The y position
----@param text string The text to set
----@return Image self The Image instance
-function Image:setText(x, y, text) end
-
----@class Table : VisualElement
----@field sortColumn number nil Currently sorted column index
----@field gridColor color Color of grid lines
----@field sortDirection string Sort direction ("asc" or "desc")
----@field data table The table data as array of row arrays
----@field columns table List of column definitions with {name, width} properties
----@field selectedColor color Background color of selected row
----@field headerColor color Color of the column headers
----@field scrollOffset number Current scroll position
----@field selectedRow number nil Currently selected row index
-local Table = {}
-
----Gets the value of the SortColumn property.
----@param self Table self
----@return number ? nil Currently sorted column index
-function Table:getSortColumn(self) end
-
----Gets the value of the SelectedColor property.
----@param self Table self
----@return color lightBlue Background color of selected row
-function Table:getSelectedColor(self) end
-
----Gets the value of the HeaderColor property.
----@param self Table self
----@return color blue Color of the column headers
-function Table:getHeaderColor(self) end
-
----Gets the value of the SortDirection property.
----@param self Table self
----@return string "asc" Sort direction ("asc" or "desc")
-function Table:getSortDirection(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Table:render() end
-
----Sets the value of the Columns property.
----@param self Table self
----@param Columns table List of column definitions with {name, width} properties
-function Table:setColumns(self, Columns) end
-
----Gets the value of the Columns property.
----@param self Table self
----@return table {} List of column definitions with {name, width} properties
-function Table:getColumns(self) end
-
----Sets the value of the Data property.
----@param self Table self
----@param Data table The table data as array of row arrays
-function Table:setData(self, Data) end
-
----Gets the value of the Data property.
----@param self Table self
----@return table {} The table data as array of row arrays
-function Table:getData(self) end
-
----Sorts the table data by column
----@param columnIndex number The index of the column to sort by
----@param fn function ? Optional custom sorting function
----@return Table self The Table instance
-function Table:sortData(columnIndex, fn) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param direction number The scroll direction (-1 up, 1 down)
----@param x number The x position of the scroll
----@param y number The y position of the scroll
----@return boolean handled Whether the event was handled
----@protected
-function Table:mouse_scroll(direction, x, y) end
-
----Sets the value of the SortDirection property.
----@param self Table self
----@param SortDirection string Sort direction ("asc" or "desc")
-function Table:setSortDirection(self, SortDirection) end
-
----Gets the value of the SelectedRow property.
----@param self Table self
----@return number ? nil Currently selected row index
-function Table:getSelectedRow(self) end
-
----Sets the value of the SelectedColor property.
----@param self Table self
----@param SelectedColor color Background color of selected row
-function Table:setSelectedColor(self, SelectedColor) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Table:mouse_click(button, x, y) end
-
----Sets the value of the GridColor property.
----@param self Table self
----@param GridColor color Color of grid lines
-function Table:setGridColor(self, GridColor) end
-
----Sets the value of the SelectedRow property.
----@param self Table self
----@param SelectedRow number nil Currently selected row index
-function Table:setSelectedRow(self, SelectedRow) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Table self The initialized instance
----@protected
-function Table:init(props, basalt) end
-
----Sets the value of the ScrollOffset property.
----@param self Table self
----@param ScrollOffset number Current scroll position
-function Table:setScrollOffset(self, ScrollOffset) end
-
----Gets the value of the ScrollOffset property.
----@param self Table self
----@return number 0 Current scroll position
-function Table:getScrollOffset(self) end
-
----Gets the value of the GridColor property.
----@param self Table self
----@return color gray Color of grid lines
-function Table:getGridColor(self) end
-
----Sets the value of the HeaderColor property.
----@param self Table self
----@param HeaderColor color Color of the column headers
-function Table:setHeaderColor(self, HeaderColor) end
-
----Sets the value of the SortColumn property.
----@param self Table self
----@param SortColumn number nil Currently sorted column index
-function Table:setSortColumn(self, SortColumn) end
-
----@class Reactive
-local Reactive = {}
-
----@class Button : VisualElement
----@field text string Button text
-local Button = {}
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Button:render() end
-
----Sets the value of the Text property.
----@param self Button self
----@param Text string Button text
-function Button:setText(self, Text) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@protected
-function Button:init(props, basalt) end
-
----Gets the value of the Text property.
----@param self Button self
----@return string Button Button text
-function Button:getText(self) end
-
----@class Benchmark
-local Benchmark = {}
-
----Gets statistics for a benchmark
----@param name string The name of the benchmark
----@return table ? stats The benchmark statistics or nil
-function API.getStats(name) end
-
----Starts a custom benchmark
----@param name string The name of the benchmark
-function API.start(name) end
-
----Clears all custom benchmarks
-function API.clearAll() end
-
----Stops a custom benchmark
----@param name string The name of the benchmark to stop
-function API.stop(name) end
-
----Clears a specific benchmark
----@param name string The name of the benchmark to clear
-function API.clear(name) end
-
----@class Dropdown : List
----@field dropdownHeight number Maximum height of the dropdown menu when open
----@field selectedText string The text to show when no item is selected
----@field dropSymbol string The symbol to show for dropdown indication
----@field isOpen boolean Whether the dropdown menu is currently open
-local Dropdown = {}
-
----Gets the value of the SelectedText property.
----@param self Dropdown self
----@return string "" The text to show when no item is selected
-function Dropdown:getSelectedText(self) end
-
----Sets the value of the IsOpen property.
----@param self Dropdown self
----@param IsOpen boolean Whether the dropdown menu is currently open
-function Dropdown:setIsOpen(self, IsOpen) end
-
----Sets the value of the DropdownHeight property.
----@param self Dropdown self
----@param DropdownHeight number Maximum height of the dropdown menu when open
-function Dropdown:setDropdownHeight(self, DropdownHeight) end
-
----Sets the value of the SelectedText property.
----@param self Dropdown self
----@param SelectedText string The text to show when no item is selected
-function Dropdown:setSelectedText(self, SelectedText) end
-
----Sets the value of the DropSymbol property.
----@param self Dropdown self
----@param DropSymbol string The symbol to show for dropdown indication
-function Dropdown:setDropSymbol(self, DropSymbol) end
-
----Gets the value of the DropSymbol property.
----@param self Dropdown self
----@return string "\31" The symbol to show for dropdown indication
-function Dropdown:getDropSymbol(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Dropdown self The initialized instance
----@protected
-function Dropdown:init(props, basalt) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Dropdown:render() end
-
----Gets the value of the DropdownHeight property.
----@param self Dropdown self
----@return number 5 Maximum height of the dropdown menu when open
-function Dropdown:getDropdownHeight(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Dropdown:mouse_click(button, x, y) end
-
----Gets the value of the IsOpen property.
----@param self Dropdown self
----@return boolean false Whether the dropdown menu is currently open
-function Dropdown:getIsOpen(self) end
-
----@class Slider : VisualElement
----@field step number Current position of the slider handle (1 to width/height)
----@field barColor color Color of the slider track
----@field horizontal boolean Whether the slider is horizontal (false for vertical)
----@field max number Maximum value for value conversion (maps slider position to this range)
----@field sliderColor color Color of the slider handle
-local Slider = {}
-
----Registers a function to handle the onChange event.
----@param value number
----@param self Slider self
----@param func function The function to be called when the event fires
-function Slider:onOnChange(self, func) end
-
----Gets the value of the Step property.
----@param self Slider self
----@return number 1 Current position of the slider handle (1 to width/height)
-function Slider:getStep(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The mouse button that was released
----@param x number The x position of the release
----@param y number The y position of the release
----@return boolean handled Whether the event was handled
----@protected
-function Slider:mouse_scroll(button, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The mouse button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Slider:mouse_click(button, x, y) end
-
----Gets the current value of the slider
----@return number value The current value (0 to max)
-function Slider:getValue() end
-
----Sets the value of the BarColor property.
----@param self Slider self
----@param BarColor color Color of the slider track
-function Slider:setBarColor(self, BarColor) end
-
----Gets the value of the BarColor property.
----@param self Slider self
----@return color gray Color of the slider track
-function Slider:getBarColor(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Slider self The initialized instance
----@protected
-function Slider:init(props, basalt) end
-
----Sets the value of the Step property.
----@param self Slider self
----@param Step number Current position of the slider handle (1 to width/height)
-function Slider:setStep(self, Step) end
-
----Gets the value of the Horizontal property.
----@param self Slider self
----@return boolean true Whether the slider is horizontal (false for vertical)
-function Slider:getHorizontal(self) end
-
----Gets the value of the Max property.
----@param self Slider self
----@return number 100 Maximum value for value conversion (maps slider position to this range)
-function Slider:getMax(self) end
-
----Sets the value of the Max property.
----@param self Slider self
----@param Max number Maximum value for value conversion (maps slider position to this range)
-function Slider:setMax(self, Max) end
-
----Sets the value of the SliderColor property.
----@param self Slider self
----@param SliderColor color Color of the slider handle
-function Slider:setSliderColor(self, SliderColor) end
-
----Gets the value of the SliderColor property.
----@param self Slider self
----@return color blue Color of the slider handle
-function Slider:getSliderColor(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Slider:render() end
-
----Sets the value of the Horizontal property.
----@param self Slider self
----@param Horizontal boolean Whether the slider is horizontal (false for vertical)
-function Slider:setHorizontal(self, Horizontal) end
-
----@class basalt
-local basalt = {}
-
----Returns a Plugin API
----@param name string The name of the plugin
----@return table Plugin The plugin API
-function basalt.getAPI(name) end
-
----Returns an element's class without creating a instance
----@param name string The name of the element
+---Gets an element by name. If the element is not loaded, it will try to load it first.
+---@param name string The name of the element to get
 ---@return table Element The element class
-function basalt.getElementClass(name) end
-
----Returns the element manager instance
----@return table ElementManager The element manager
-function basalt.getElementManager() end
-
----Creates and returns a new UI element of the specified type.
----@param type string The type of element to create (e.g. "Button", "Label", "BaseFrame")
----@return table element The created element instance
-function basalt.create(type) end
-
----Starts the Basalt runtime
-function basalt.run() end
-
----Stops the Basalt runtime
-function basalt.stop() end
-
----Runs basalt once, can be used to update the UI manually, but you have to feed it the events
-function basalt.update() end
-
----Removes a scheduled update
----@param func thread The scheduled function to remove
----@return boolean success Whether the scheduled function was removed
-function basalt.removeSchedule(func) end
-
----Sets the active frame
----@param frame BaseFrame The frame to set as active
-function basalt.setActiveFrame(frame) end
-
----Creates and returns a new BaseFrame
----@return BaseFrame BaseFrame The created frame instance
-function basalt.createFrame() end
-
----Sets a frame as focused
----@param frame BaseFrame The frame to set as focused
-function basalt.setFocus(frame) end
-
----Returns the error manager instance
----@return table ErrorManager The error manager
-function basalt.getErrorManager() end
-
----Schedules a function to run in a coroutine
----@param func function The function to schedule
----@return thread func The scheduled function
-function basalt.schedule(func) end
-
----Gets or creates the main frame
----@return BaseFrame BaseFrame The main frame instance
-function basalt.getMainFrame() end
-
----Returns the focused frame
----@return BaseFrame ? BaseFrame The focused frame
-function basalt.getFocus() end
-
----Returns the active frame
----@return BaseFrame ? BaseFrame The frame to set as active
-function basalt.getActiveFrame() end
-
----@class Frame : Container
----@field draggingMap table The map of dragging positions
----@field draggable boolean Whether the frame is draggable
-local Frame = {}
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@return Frame self The initialized instance
----@protected
-function Frame:init(props, basalt) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the drag position
----@param y number The y position of the drag position
----@return boolean handled Whether the event was handled
----@protected
-function Frame:mouse_drag(button, x, y) end
-
----Sets the value of the Draggable property.
----@param self Frame self
----@param Draggable boolean Whether the frame is draggable
-function Frame:setDraggable(self, Draggable) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was released
----@param x number The x position of the release
----@param y number The y position of the release
----@return boolean handled Whether the event was handled
----@protected
-function Frame:mouse_up(button, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Frame:mouse_click(button, x, y) end
-
----Sets the value of the DraggingMap property.
----@param self Frame self
----@param DraggingMap table The map of dragging positions
-function Frame:setDraggingMap(self, DraggingMap) end
-
----Gets the value of the Draggable property.
----@param self Frame self
----@return boolean false Whether the frame is draggable
-function Frame:getDraggable(self) end
-
----Gets the value of the DraggingMap property.
----@param self Frame self
----@return table {} The map of dragging positions
-function Frame:getDraggingMap(self) end
-
----@class Container : VisualElement
----@field offsetY number Vertical content offset
----@field offsetX number Horizontal content offset
----@field focusedChild table The focused child of the container
----@field childrenEventsSorted boolean Whether the children events are sorted
----@field childrenSorted boolean Whether the children are sorted
----@field visibleChildrenEvents table The visible children events of the container
----@field visibleChildren table The visible children of the container
----@field eventListenerCount table The event listener count of the container
----@field children table The children of the container
----@field childrenEvents table The children events of the container
-local Container = {}
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was released
----@return boolean handled Whether the event was handled
----@protected
-function Container:key_up(key) end
-
----Gets the value of the OffsetY property.
----@param self Container self
----@return number 0 Vertical content offset
-function Container:getOffsetY(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Container:mouse_up(button, x, y) end
-
----Sets the value of the Children property.
----@param self Container self
----@param Children table The children of the container
-function Container:setChildren(self, Children) end
-
----Removes a child from the container
----@param child table The child to remove
----@return Container self The container instance
-function Container:removeChild(child) end
-
----Creates a new BarChart element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return BarChart element A new BarChart element.
-function Container:addBarChart(self, props) end
-
----Clears the container
----@return Container self The container instance
-function Container:clear() end
-
----Creates a new Program element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Program element A new Program element.
-function Container:addProgram(self, props) end
-
----Sets the value of the EventListenerCount property.
----@param self Container self
----@param EventListenerCount table The event listener count of the container
-function Container:setEventListenerCount(self, EventListenerCount) end
-
----Creates a new List element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return List element A new List element.
-function Container:addList(self, props) end
-
----Gets the value of the ChildrenEvents property.
----@param self Container self
----@return table {} The children events of the container
-function Container:getChildrenEvents(self) end
-
----Creates a new Switch element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Switch element A new Switch element.
-function Container:addSwitch(self, props) end
-
----Gets the value of the ChildrenEventsSorted property.
----@param self Container self
----@return boolean true Whether the children events are sorted
-function Container:getChildrenEventsSorted(self) end
-
----Gets the value of the FocusedChild property.
----@param self Container self
----@return table nil The focused child of the container
-function Container:getFocusedChild(self) end
-
-function Container:drawText() end
-
----Creates a new Container element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Container element A new Container element.
-function Container:addContainer(self, props) end
-
----Creates a new Frame element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Frame element A new Frame element.
-function Container:addFrame(self, props) end
-
----Registers the children events of the container
----@param child table The child to register events for
----@param eventName string The event name to register
----@return Container self The container instance
-function Container:registerChildEvent(child, eventName) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Container:mouse_click(button, x, y) end
-
----Gets the value of the VisibleChildren property.
----@param self Container self
----@return table {} The visible children of the container
-function Container:getVisibleChildren(self) end
-
----Unregisters the children events of the container
----@param child table The child to unregister events for
----@param eventName string The event name to unregister
----@return Container self The container instance
-function Container:unregisterChildEvent(child, eventName) end
-
----Gets the value of the VisibleChildrenEvents property.
----@param self Container self
----@return table {} The visible children events of the container
-function Container:getVisibleChildrenEvents(self) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param event string The event to handle
----@return boolean handled Whether the event was handled
----@protected
-function Container:handleEvent(event) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param props table The properties to initialize the element with
----@param basalt table The basalt instance
----@protected
-function Container:init(props, basalt) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw the text
----@param y number The y position to draw the text
----@param text string The text to draw
----@param fg string The foreground color of the text
----@param bg string The background color of the text
----@return Container self The container instance
----@protected
-function Container:blit(x, y, text, fg, bg) end
-
----Creates a new Slider element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Slider element A new Slider element.
-function Container:addSlider(self, props) end
-
----Gets the value of the ChildrenSorted property.
----@param self Container self
----@return boolean true Whether the children are sorted
-function Container:getChildrenSorted(self) end
-
-function Container:drawFg() end
-
----Enables debugging for this container and all its children
----@param self Container The container to debug
----@param level number The debug level
-function Container.debugChildren(self, level) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw the text
----@param y number The y position to draw the text
----@param text string The text to draw
----@param bg color The background color of the text
----@return Container self The container instance
----@protected
-function Container:textBg(x, y, text, bg) end
-
----Creates a new Tree element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Tree element A new Tree element.
-function Container:addTree(self, props) end
-
----Sorts the children of the container
----@return Container self The container instance
-function Container:sortChildren() end
-
----Creates a new BaseFrame element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return BaseFrame element A new BaseFrame element.
-function Container:addBaseFrame(self, props) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param char string The character that was pressed
----@return boolean handled Whether the event was handled
----@protected
-function Container:char(char) end
-
----Creates a new TextBox element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return TextBox element A new TextBox element.
-function Container:addTextBox(self, props) end
-
----Creates a new Checkbox element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Checkbox element A new Checkbox element.
-function Container:addCheckbox(self, props) end
-
----Removes a child from the container
----@param path string The path to the child to remove
----@return Container ? self The container instance
-function Container:getChild(path) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@protected
-function Container:render() end
-
----Sorts the children events of the container
----@param eventName string The event name to sort
----@return Container self The container instance
-function Container:sortChildrenEvents(eventName) end
-
----Creates a new Graph element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Graph element A new Graph element.
-function Container:addGraph(self, props) end
-
----Registers the children events of the container
----@param child table The child to register events for
----@return Container self The container instance
-function Container:registerChildrenEvents(child) end
-
----Sets the value of the OffsetX property.
----@param self Container self
----@param OffsetX number Horizontal content offset
-function Container:setOffsetX(self, OffsetX) end
-
----Stops benchmarking for a container and all its children
----@param methodName string The method to stop benchmarking
----@return Container self The container instance
-function Container:stopContainerBenchmark(methodName) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Container:mouse_drag(button, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param button number The button that was clicked
----@param x number The x position of the click
----@param y number The y position of the click
----@protected
-function Container:mouse_release(button, x, y) end
-
----Creates a new Table element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Table element A new Table element.
-function Container:addTable(self, props) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param direction number The direction of the scroll
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Container:mouse_scroll(direction, x, y) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param _ number unknown
----@param x number The x position of the click
----@param y number The y position of the click
----@return boolean handled Whether the event was handled
----@protected
-function Container:mouse_move(_, x, y) end
-
----Sets the value of the ChildrenEvents property.
----@param self Container self
----@param ChildrenEvents table The children events of the container
-function Container:setChildrenEvents(self, ChildrenEvents) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param key number The key that was pressed
----@return boolean handled Whether the event was handled
----@protected
-function Container:key(key) end
-
----Creates a new VisualElement element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return VisualElement element A new VisualElement element.
-function Container:addVisualElement(self, props) end
-
----Creates a new Button element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Button element A new Button element.
-function Container:addButton(self, props) end
-
----Sets the value of the ChildrenEventsSorted property.
----@param self Container self
----@param ChildrenEventsSorted boolean Whether the children events are sorted
-function Container:setChildrenEventsSorted(self, ChildrenEventsSorted) end
-
----Gets the value of the Children property.
----@param self Container self
----@return table {} The children of the container
-function Container:getChildren(self) end
-
----Calls a event on all children
----@param visibleOnly boolean Whether to only call the event on visible children
----@param event string The event to call
----@return boolean handled Whether the event was handled
----@return table ? child The child that handled the event
-function Container:callChildrenEvent(visibleOnly, event) end
-
-function Container:drawBg() end
-
----Creates a new Flexbox element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Flexbox element A new Flexbox element.
-function Container:addFlexbox(self, props) end
-
----Gets the value of the EventListenerCount property.
----@param self Container self
----@return table {} The event listener count of the container
-function Container:getEventListenerCount(self) end
-
----Creates a new Menu element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Menu element A new Menu element.
-function Container:addMenu(self, props) end
-
----Creates a new Label element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Label element A new Label element.
-function Container:addLabel(self, props) end
-
----Returns whether a child is visible
----@param child table The child to check
----@return boolean boolean the child is visible
-function Container:isChildVisible(child) end
-
----Sets the value of the VisibleChildren property.
----@param self Container self
----@param VisibleChildren table The visible children of the container
-function Container:setVisibleChildren(self, VisibleChildren) end
-
----Enables benchmarking for a container and all its children
----@param methodName string The method to benchmark
----@return Container self The container instance
-function Container:benchmarkContainer(methodName) end
-
----Creates a new BigFont element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return BigFont element A new BigFont element.
-function Container:addBigFont(self, props) end
-
----Sets the value of the VisibleChildrenEvents property.
----@param self Container self
----@param VisibleChildrenEvents table The visible children events of the container
-function Container:setVisibleChildrenEvents(self, VisibleChildrenEvents) end
-
----Gets the value of the OffsetX property.
----@param self Container self
----@return number 0 Horizontal content offset
-function Container:getOffsetX(self) end
-
----Creates a new Dropdown element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Dropdown element A new Dropdown element.
-function Container:addDropdown(self, props) end
-
----Creates a new BaseElement element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return BaseElement element A new BaseElement element.
-function Container:addBaseElement(self, props) end
-
----Logs benchmark statistics for a container and all its children
----@param methodName string The method to log
----@return Container self The container instance
-function Container:logContainerBenchmarks(methodName) end
-
----Creates a new ProgressBar element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return ProgressBar element A new ProgressBar element.
-function Container:addProgressBar(self, props) end
-
----Unregisters the children events of the container
----@param child table The child to unregister events for
----@return Container self The container instance
-function Container:removeChildrenEvents(child) end
-
----Creates a new Input element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Input element A new Input element.
-function Container:addInput(self, props) end
-
----Adds a child to the container
----@param child table The child to add
----@return Container self The container instance
-function Container:addChild(child) end
-
----Sets the value of the ChildrenSorted property.
----@param self Container self
----@param ChildrenSorted boolean Whether the children are sorted
-function Container:setChildrenSorted(self, ChildrenSorted) end
-
----Creates a new Scrollbar element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Scrollbar element A new Scrollbar element.
-function Container:addScrollbar(self, props) end
-
----Creates a new LineChart element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return LineChart element A new LineChart element.
-function Container:addLineChart(self, props) end
-
----Creates a new Image element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Image element A new Image element.
-function Container:addImage(self, props) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw the text
----@param y number The y position to draw the text
----@param text string The text to draw
----@param fg color The foreground color of the text
----@return Container self The container instance
----@protected
-function Container:textFg(x, y, text, fg) end
-
----Creates a new Display element.
----@param self Container self
----@param props? table Optional: properties for the element.
----@return Display element A new Display element.
-function Container:addDisplay(self, props) end
-
----Sets the value of the OffsetY property.
----@param self Container self
----@param OffsetY number Vertical content offset
-function Container:setOffsetY(self, OffsetY) end
-
----This function is protected and should not be called outside of basalt, however you can overwrite it if you know what you're doing.
----@param x number The x position to draw the text
----@param y number The y position to draw the text
----@param width number The width of the text
----@param height number The height of the text
----@param text string The text to draw
----@param fg string The foreground color of the text
----@param bg string The background color of the text
----@return Container self The container instance
----@protected
-function Container:multiBlit(x, y, width, height, text, fg, bg) end
-
----Sets the value of the FocusedChild property.
----@param self Container self
----@param FocusedChild table The focused child of the container
-function Container:setFocusedChild(self, FocusedChild) end
+function ElementManager.getElement(name) end
 

--- a/config.lua
+++ b/config.lua
@@ -1,413 +1,413 @@
 return {
+  ["metadata"] = {
+    ["version"] = "2.0",
+    ["generated"] = "Sat Apr 19 16:22:32 2025",
+  },
   ["categories"] = {
     ["core"] = {
       ["description"] = "Core Files",
       ["files"] = {
-        ["main"] = {
-          ["path"] = "main.lua",
-          ["default"] = true,
-          ["size"] = 10456,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
-        ["elementManager"] = {
-          ["path"] = "elementManager.lua",
-          ["default"] = true,
-          ["size"] = 6297,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
-        ["propertySystem"] = {
-          ["path"] = "propertySystem.lua",
-          ["default"] = true,
-          ["size"] = 15524,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
         ["render"] = {
+          ["size"] = 12422,
           ["path"] = "render.lua",
           ["default"] = true,
-          ["size"] = 12422,
-          ["description"] = "",
           ["requires"] = {
           },
+          ["description"] = "",
         },
         ["errorManager"] = {
+          ["size"] = 3789,
           ["path"] = "errorManager.lua",
           ["default"] = true,
-          ["size"] = 3789,
-          ["description"] = "",
           ["requires"] = {
           },
+          ["description"] = "",
         },
-        ["log"] = {
-          ["path"] = "log.lua",
+        ["main"] = {
+          ["size"] = 10456,
+          ["path"] = "main.lua",
           ["default"] = true,
-          ["size"] = 3142,
-          ["description"] = "",
           ["requires"] = {
           },
+          ["description"] = "",
         },
         ["init"] = {
+          ["size"] = 583,
           ["path"] = "init.lua",
           ["default"] = true,
-          ["size"] = 583,
-          ["description"] = "",
           ["requires"] = {
           },
+          ["description"] = "",
         },
-      },
-    },
-    ["plugins"] = {
-      ["description"] = "Plugins",
-      ["files"] = {
-        ["animation"] = {
-          ["path"] = "plugins/animation.lua",
+        ["elementManager"] = {
+          ["size"] = 6297,
+          ["path"] = "elementManager.lua",
           ["default"] = true,
-          ["size"] = 14731,
-          ["description"] = "",
           ["requires"] = {
           },
+          ["description"] = "",
         },
-        ["debug"] = {
-          ["path"] = "plugins/debug.lua",
+        ["log"] = {
+          ["size"] = 3142,
+          ["path"] = "log.lua",
           ["default"] = true,
-          ["size"] = 6250,
-          ["description"] = "",
           ["requires"] = {
           },
+          ["description"] = "",
         },
-        ["state"] = {
-          ["path"] = "plugins/state.lua",
+        ["propertySystem"] = {
+          ["size"] = 15524,
+          ["path"] = "propertySystem.lua",
           ["default"] = true,
-          ["size"] = 6896,
-          ["description"] = "",
-          ["requires"] = {
-            [1] = "Container",
-          },
-        },
-        ["canvas"] = {
-          ["path"] = "plugins/canvas.lua",
-          ["default"] = true,
-          ["size"] = 7873,
-          ["description"] = "",
           ["requires"] = {
           },
-        },
-        ["reactive"] = {
-          ["path"] = "plugins/reactive.lua",
-          ["default"] = true,
-          ["size"] = 7193,
           ["description"] = "",
-          ["requires"] = {
-          },
-        },
-        ["xml"] = {
-          ["path"] = "plugins/xml.lua",
-          ["default"] = true,
-          ["size"] = 9901,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
-        ["benchmark"] = {
-          ["path"] = "plugins/benchmark.lua",
-          ["default"] = true,
-          ["size"] = 12581,
-          ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["theme"] = {
-          ["path"] = "plugins/theme.lua",
-          ["default"] = true,
-          ["size"] = 7166,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
-      },
-    },
-    ["libraries"] = {
-      ["description"] = "Libraries",
-      ["files"] = {
-        ["colorHex"] = {
-          ["path"] = "libraries/colorHex.lua",
-          ["default"] = true,
-          ["size"] = 132,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
-        ["expect"] = {
-          ["path"] = "libraries/expect.lua",
-          ["default"] = true,
-          ["size"] = 846,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
-        ["utils"] = {
-          ["path"] = "libraries/utils.lua",
-          ["default"] = true,
-          ["size"] = 2661,
-          ["description"] = "",
-          ["requires"] = {
-          },
         },
       },
     },
     ["elements"] = {
       ["description"] = "UI Elements",
       ["files"] = {
-        ["List"] = {
-          ["path"] = "elements/List.lua",
+        ["Scrollbar"] = {
+          ["size"] = 9191,
+          ["path"] = "elements/Scrollbar.lua",
           ["default"] = true,
-          ["size"] = 8702,
-          ["description"] = "A scrollable list of selectable items",
           ["requires"] = {
             [1] = "VisualElement",
           },
-        },
-        ["Switch"] = {
-          ["path"] = "elements/Switch.lua",
-          ["default"] = true,
-          ["size"] = 1378,
           ["description"] = "",
+        },
+        ["Label"] = {
+          ["size"] = 3092,
+          ["path"] = "elements/Label.lua",
+          ["default"] = true,
           ["requires"] = {
             [1] = "VisualElement",
           },
+          ["description"] = "A simple text display element that automatically resizes its width based on the text content.",
         },
-        ["Frame"] = {
-          ["path"] = "elements/Frame.lua",
+        ["Slider"] = {
+          ["size"] = 4766,
+          ["path"] = "elements/Slider.lua",
           ["default"] = true,
-          ["size"] = 4458,
-          ["description"] = "A frame element that serves as a grouping container for other elements.",
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "",
+        },
+        ["LineChart"] = {
+          ["size"] = 3227,
+          ["path"] = "elements/LineChart.lua",
+          ["default"] = false,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["BaseFrame"] = {
+          ["size"] = 8466,
+          ["path"] = "elements/BaseFrame.lua",
+          ["default"] = true,
           ["requires"] = {
             [1] = "Container",
           },
+          ["description"] = "This is the base frame class. It is the root element of all elements and the only element without a parent.",
         },
-        ["TextBox"] = {
-          ["path"] = "elements/TextBox.lua",
-          ["default"] = false,
-          ["size"] = 10929,
-          ["description"] = "A multi-line text editor component with cursor support and text manipulation features",
+        ["Checkbox"] = {
+          ["size"] = 2928,
+          ["path"] = "elements/Checkbox.lua",
+          ["default"] = true,
           ["requires"] = {
             [1] = "VisualElement",
           },
+          ["description"] = "",
+        },
+        ["ProgressBar"] = {
+          ["size"] = 3397,
+          ["path"] = "elements/ProgressBar.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "",
         },
         ["VisualElement"] = {
+          ["size"] = 17775,
           ["path"] = "elements/VisualElement.lua",
           ["default"] = true,
-          ["size"] = 17775,
-          ["description"] = "The Visual Element class which is the base class for all visual UI elements",
           ["requires"] = {
             [1] = "BaseElement",
           },
+          ["description"] = "The Visual Element class which is the base class for all visual UI elements",
         },
-        ["Label"] = {
-          ["path"] = "elements/Label.lua",
+        ["Switch"] = {
+          ["size"] = 1378,
+          ["path"] = "elements/Switch.lua",
           ["default"] = true,
-          ["size"] = 3092,
-          ["description"] = "A simple text display element that automatically resizes its width based on the text content.",
           ["requires"] = {
             [1] = "VisualElement",
           },
-        },
-        ["BaseFrame"] = {
-          ["path"] = "elements/BaseFrame.lua",
-          ["default"] = true,
-          ["size"] = 8466,
-          ["description"] = "This is the base frame class. It is the root element of all elements and the only element without a parent.",
-          ["requires"] = {
-            [1] = "Container",
-          },
-        },
-        ["Flexbox"] = {
-          ["path"] = "elements/Flexbox.lua",
-          ["default"] = true,
-          ["size"] = 12215,
-          ["description"] = "A flexbox container that arranges its children in a flexible layout.",
-          ["requires"] = {
-            [1] = "Container",
-          },
-        },
-        ["Input"] = {
-          ["path"] = "elements/Input.lua",
-          ["default"] = true,
-          ["size"] = 8876,
-          ["description"] = "A text input field with various features",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["Container"] = {
-          ["path"] = "elements/Container.lua",
-          ["default"] = true,
-          ["size"] = 25030,
-          ["description"] = "The container class. It is a visual element that can contain other elements. It is the base class for all containers",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["Tree"] = {
-          ["path"] = "elements/Tree.lua",
-          ["default"] = true,
-          ["size"] = 7941,
           ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["Slider"] = {
-          ["path"] = "elements/Slider.lua",
-          ["default"] = true,
-          ["size"] = 4766,
-          ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["Image"] = {
-          ["path"] = "elements/Image.lua",
-          ["default"] = false,
-          ["size"] = 15125,
-          ["description"] = "An element that displays an image in bimg format",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["Graph"] = {
-          ["path"] = "elements/Graph.lua",
-          ["default"] = false,
-          ["size"] = 6990,
-          ["description"] = "A point based graph element",
-          ["requires"] = {
-          },
-        },
-        ["ProgressBar"] = {
-          ["path"] = "elements/ProgressBar.lua",
-          ["default"] = true,
-          ["size"] = 3397,
-          ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
         },
         ["BigFont"] = {
+          ["size"] = 20951,
           ["path"] = "elements/BigFont.lua",
           ["default"] = false,
-          ["size"] = 20951,
-          ["description"] = "",
           ["requires"] = {
             [1] = "VisualElement",
           },
-        },
-        ["Program"] = {
-          ["path"] = "elements/Program.lua",
-          ["default"] = true,
-          ["size"] = 7733,
           ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["BaseElement"] = {
-          ["path"] = "elements/BaseElement.lua",
-          ["default"] = true,
-          ["size"] = 9544,
-          ["description"] = "The base class for all UI elements in Basalt.",
-          ["requires"] = {
-          },
-        },
-        ["Dropdown"] = {
-          ["path"] = "elements/Dropdown.lua",
-          ["default"] = false,
-          ["size"] = 6359,
-          ["description"] = "A dropdown menu that shows a list of selectable items",
-          ["requires"] = {
-            [1] = "List",
-          },
-        },
-        ["Button"] = {
-          ["path"] = "elements/Button.lua",
-          ["default"] = true,
-          ["size"] = 1656,
-          ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["Checkbox"] = {
-          ["path"] = "elements/Checkbox.lua",
-          ["default"] = true,
-          ["size"] = 2928,
-          ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
         },
         ["BarChart"] = {
+          ["size"] = 3190,
           ["path"] = "elements/BarChart.lua",
           ["default"] = false,
-          ["size"] = 3190,
-          ["description"] = "",
           ["requires"] = {
           },
+          ["description"] = "",
         },
-        ["Display"] = {
-          ["path"] = "elements/Display.lua",
-          ["default"] = false,
-          ["size"] = 4243,
-          ["description"] = "The Display is a special element which uses the cc window API which you can use.",
+        ["Program"] = {
+          ["size"] = 7733,
+          ["path"] = "elements/Program.lua",
+          ["default"] = true,
           ["requires"] = {
             [1] = "VisualElement",
           },
+          ["description"] = "",
+        },
+        ["Table"] = {
+          ["size"] = 8811,
+          ["path"] = "elements/Table.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "",
+        },
+        ["Button"] = {
+          ["size"] = 1656,
+          ["path"] = "elements/Button.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "",
         },
         ["Menu"] = {
+          ["size"] = 4679,
           ["path"] = "elements/Menu.lua",
           ["default"] = true,
-          ["size"] = 4679,
-          ["description"] = "A horizontal menu bar with selectable items.",
           ["requires"] = {
             [1] = "List",
           },
+          ["description"] = "A horizontal menu bar with selectable items.",
         },
-        ["Scrollbar"] = {
-          ["path"] = "elements/Scrollbar.lua",
-          ["default"] = true,
-          ["size"] = 9191,
-          ["description"] = "",
-          ["requires"] = {
-            [1] = "VisualElement",
-          },
-        },
-        ["LineChart"] = {
-          ["path"] = "elements/LineChart.lua",
+        ["Display"] = {
+          ["size"] = 4243,
+          ["path"] = "elements/Display.lua",
           ["default"] = false,
-          ["size"] = 3227,
-          ["description"] = "",
-          ["requires"] = {
-          },
-        },
-        ["Table"] = {
-          ["path"] = "elements/Table.lua",
-          ["default"] = true,
-          ["size"] = 8680,
-          ["description"] = "",
           ["requires"] = {
             [1] = "VisualElement",
           },
+          ["description"] = "The Display is a special element which uses the cc window API which you can use.",
+        },
+        ["BaseElement"] = {
+          ["size"] = 9544,
+          ["path"] = "elements/BaseElement.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "The base class for all UI elements in Basalt.",
+        },
+        ["Frame"] = {
+          ["size"] = 4458,
+          ["path"] = "elements/Frame.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "Container",
+          },
+          ["description"] = "A frame element that serves as a grouping container for other elements.",
+        },
+        ["Container"] = {
+          ["size"] = 25030,
+          ["path"] = "elements/Container.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "The container class. It is a visual element that can contain other elements. It is the base class for all containers",
+        },
+        ["Graph"] = {
+          ["size"] = 6990,
+          ["path"] = "elements/Graph.lua",
+          ["default"] = false,
+          ["requires"] = {
+          },
+          ["description"] = "A point based graph element",
+        },
+        ["Flexbox"] = {
+          ["size"] = 12215,
+          ["path"] = "elements/Flexbox.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "Container",
+          },
+          ["description"] = "A flexbox container that arranges its children in a flexible layout.",
+        },
+        ["Tree"] = {
+          ["size"] = 7941,
+          ["path"] = "elements/Tree.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "",
+        },
+        ["Input"] = {
+          ["size"] = 8876,
+          ["path"] = "elements/Input.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "A text input field with various features",
+        },
+        ["Dropdown"] = {
+          ["size"] = 6359,
+          ["path"] = "elements/Dropdown.lua",
+          ["default"] = false,
+          ["requires"] = {
+            [1] = "List",
+          },
+          ["description"] = "A dropdown menu that shows a list of selectable items",
+        },
+        ["TextBox"] = {
+          ["size"] = 10929,
+          ["path"] = "elements/TextBox.lua",
+          ["default"] = false,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "A multi-line text editor component with cursor support and text manipulation features",
+        },
+        ["List"] = {
+          ["size"] = 8702,
+          ["path"] = "elements/List.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "A scrollable list of selectable items",
+        },
+        ["Image"] = {
+          ["size"] = 15125,
+          ["path"] = "elements/Image.lua",
+          ["default"] = false,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "An element that displays an image in bimg format",
         },
       },
     },
-  },
-  ["metadata"] = {
-    ["version"] = "2.0",
-    ["generated"] = "Sat Apr 19 07:21:46 2025",
+    ["plugins"] = {
+      ["description"] = "Plugins",
+      ["files"] = {
+        ["xml"] = {
+          ["size"] = 9901,
+          ["path"] = "plugins/xml.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["animation"] = {
+          ["size"] = 14731,
+          ["path"] = "plugins/animation.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["state"] = {
+          ["size"] = 6896,
+          ["path"] = "plugins/state.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "Container",
+          },
+          ["description"] = "",
+        },
+        ["reactive"] = {
+          ["size"] = 7193,
+          ["path"] = "plugins/reactive.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["theme"] = {
+          ["size"] = 7166,
+          ["path"] = "plugins/theme.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["benchmark"] = {
+          ["size"] = 12581,
+          ["path"] = "plugins/benchmark.lua",
+          ["default"] = true,
+          ["requires"] = {
+            [1] = "VisualElement",
+          },
+          ["description"] = "",
+        },
+        ["canvas"] = {
+          ["size"] = 7873,
+          ["path"] = "plugins/canvas.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["debug"] = {
+          ["size"] = 6250,
+          ["path"] = "plugins/debug.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+      },
+    },
+    ["libraries"] = {
+      ["description"] = "Libraries",
+      ["files"] = {
+        ["expect"] = {
+          ["size"] = 846,
+          ["path"] = "libraries/expect.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["colorHex"] = {
+          ["size"] = 132,
+          ["path"] = "libraries/colorHex.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+        ["utils"] = {
+          ["size"] = 2661,
+          ["path"] = "libraries/utils.lua",
+          ["default"] = true,
+          ["requires"] = {
+          },
+          ["description"] = "",
+        },
+      },
+    },
   },
 }

--- a/release/basalt.lua
+++ b/release/basalt.lua
@@ -1538,8 +1538,9 @@ if bc and(ac+1)<=#ca then db=1
 local cc=
 (ac+1)==da and self.get("selectedColor")or self.get("background")
 for dc,_d in ipairs(ba)do local ad=tostring(bc[dc]or"")local bd=ad..
-string.rep(" ",_d.width-#ad)
-self:blit(db,y,string.sub(bd,1,cb-db+1),string.sub(string.rep(_a[self.get("foreground")],_d.width),1,
+string.rep(" ",_d.width-#ad)if dc<#ba then bd=
+string.sub(bd,1,_d.width-1).." "end
+self:blit(db,y,string.sub(bd,1,_d.width),string.sub(string.rep(_a[self.get("foreground")],_d.width),1,
 cb-db+1),string.sub(string.rep(_a[cc],_d.width),1,
 cb-db+1))db=db+_d.width end else
 self:blit(1,y,string.rep(" ",self.get("width")),string.rep(_a[self.get("foreground")],self.get("width")),string.rep(_a[self.get("background")],self.get("width")))end end

--- a/src/elements/Flexbox.lua
+++ b/src/elements/Flexbox.lua
@@ -31,6 +31,19 @@ Flexbox.defineProperty(Flexbox, "flexJustifyContent", {
         return value
     end
 })
+---@property flexAlignItems string "flex-start" The alignment of flex items along the cross axis
+Flexbox.defineProperty(Flexbox, "flexAlignItems", {
+    default = "flex-start",
+    type = "string",
+    setter = function(self, value)
+        if not value:match("^flex%-") and value ~= "stretch" then
+            value = "flex-" .. value
+        end
+        return value
+    end
+})
+---@property flexCrossPadding number 0 The padding on both sides of the cross axis
+Flexbox.defineProperty(Flexbox, "flexCrossPadding", {default = 0, type = "number"})
 ---@property flexWrap boolean false Whether to wrap flex items onto multiple lines
 ---@property flexUpdateLayout boolean false Whether to update the layout of the flexbox
 Flexbox.defineProperty(Flexbox, "flexWrap", {default = false, type = "boolean"})
@@ -57,187 +70,576 @@ local lineBreakElement = {
 
 
 local function sortElements(self, direction, spacing, wrap)
+    -- Pre-allocate tables to reduce dynamic expansion
     local elements = self.get("children")
     local sortedElements = {}
-    if not(wrap)then
-      local index = 1
-      local lineSize = 1
-      local lineOffset = 1
-      for _,v in pairs(elements)do
-          if(sortedElements[index]==nil)then sortedElements[index]={offset=1} end
-
-          local childHeight = direction == "row" and v.get("height") or v.get("width")
-          if childHeight > lineSize then
-              lineSize = childHeight
-          end
-          if(v == lineBreakElement)then
-              lineOffset = lineOffset + lineSize + spacing
-              lineSize = 1
-              index = index + 1
-              sortedElements[index] = {offset=lineOffset}
-          else
-              table.insert(sortedElements[index], v)
-          end
-      end
-    elseif(wrap)then
-      local lineSize = 1
-      local lineOffset = 1
-
-      local maxSize = direction == "row" and self.get("width") or self.get("height")
-      local usedSize = 0
-      local index = 1
-
-      for _,v in pairs(elements) do
-          if(sortedElements[index]==nil) then sortedElements[index]={offset=1} end
-
-          if v:getType() == "lineBreak" then
-              lineOffset = lineOffset + lineSize + spacing
-              usedSize = 0
-              lineSize = 1
-              index = index + 1
-              sortedElements[index] = {offset=lineOffset}
-          else
-              local objSize = direction == "row" and v.get("width") or v.get("height")
-              if(objSize+usedSize<=maxSize) then
-                  table.insert(sortedElements[index], v)
-                  usedSize = usedSize + objSize + spacing
-              else
-                  lineOffset = lineOffset + lineSize + spacing
-                  lineSize = direction == "row" and v.get("height") or v.get("width")
-                  index = index + 1
-                  usedSize = objSize + spacing
-                  sortedElements[index] = {offset=lineOffset, v}
-              end
-
-              local childHeight = direction == "row" and v.get("height") or v.get("width")
-              if childHeight > lineSize then
-                  lineSize = childHeight
-              end
-          end
-      end
-  end
+    local visibleElements = {}
+    local childCount = 0
+    
+    -- First calculate the number of visible elements, pre-allocate space
+    for _, elem in pairs(elements) do
+        if elem ~= lineBreakElement and elem:getVisible() then
+            childCount = childCount + 1
+        end
+    end
+    
+    -- Use known size to pre-allocate array
+    if not wrap then
+        -- No-wrap mode, all elements in one row/column
+        sortedElements[1] = {offset=1}
+        
+        for _, elem in pairs(elements) do
+            if elem == lineBreakElement then
+                -- Create new line
+                local nextIndex = #sortedElements + 1
+                if sortedElements[nextIndex] == nil then
+                    sortedElements[nextIndex] = {offset=1}
+                end
+            else
+                table.insert(sortedElements[#sortedElements], elem)
+            end
+        end
+    else
+        -- Wrap mode, need to calculate rows/columns
+        local index = 1
+        local containerSize = direction == "row" and self.get("width") or self.get("height")
+        local remainingSpace = containerSize
+        sortedElements[index] = {offset=1}
+        
+        for _, elem in pairs(elements) do
+            if elem == lineBreakElement then
+                -- Create new line
+                index = index + 1
+                sortedElements[index] = {offset=1}
+                remainingSpace = containerSize
+            else
+                local elemSize = direction == "row" and elem.get("width") or elem.get("height")
+                if elemSize + spacing <= remainingSpace then
+                    -- Element fits in current line
+                    table.insert(sortedElements[index], elem)
+                    remainingSpace = remainingSpace - elemSize - spacing
+                else
+                    -- Need new line
+                    index = index + 1
+                    sortedElements[index] = {offset=1, elem}
+                    remainingSpace = containerSize - elemSize - spacing
+                end
+            end
+        end
+    end
+    
     return sortedElements
 end
 
 local function calculateRow(self, children, spacing, justifyContent)
     local containerWidth = self.get("width")
-
-    local usedSpace = spacing * (#children - 1)
+    local containerHeight = self.get("height")
+    local alignItems = self.get("flexAlignItems")
+    local crossPadding = self.get("flexCrossPadding")
+    
+    -- Safety check
+    if containerWidth <= 0 then return end
+    
+    -- Calculate available cross axis space (considering padding)
+    local availableCrossAxisSpace = containerHeight - (crossPadding * 2)
+    if availableCrossAxisSpace < 1 then
+        availableCrossAxisSpace = containerHeight
+        crossPadding = 0
+    end
+    
+    -- Cache local variables to reduce function calls
+    local max = math.max
+    local min = math.min
+    local floor = math.floor
+    local ceil = math.ceil
+    
+    -- Fixed elements
+    local fixedElements = {}
+    -- Flexible elements
+    local flexElements = {}
+    -- Total flex coefficient
     local totalFlexGrow = 0
-
+    -- Pre-allocate capacity
+    local fixedCount = 0
+    local flexCount = 0
+    
+    -- First calculate element counts to pre-allocate space
     for _, child in ipairs(children) do
         if child ~= lineBreakElement then
-            usedSpace = usedSpace + child.get("width")
-            totalFlexGrow = totalFlexGrow + child.get("flexGrow")
+            local grow = child.get("flexGrow") or 0
+            if grow > 0 then
+                flexCount = flexCount + 1
+            else
+                fixedCount = fixedCount + 1
+            end
         end
     end
-
-    local remainingSpace = containerWidth - usedSpace
-    local extraSpacePerUnit = totalFlexGrow > 0 and (remainingSpace / totalFlexGrow) or 0
-    local distributedSpace = 0
-
-    local currentX = 1
-    for i, child in ipairs(children) do
+    
+    -- Pre-allocate table space
+    for i = 1, fixedCount do fixedElements[i] = nil end
+    
+    -- Step 1: Categorize elements and collect information
+    for _, child in ipairs(children) do
         if child ~= lineBreakElement then
-            local childWidth = child.get("width")
-
-            if child.get("flexGrow") > 0 then
-
-                if i == #children then
-                    local extraSpace = remainingSpace - distributedSpace
-                    childWidth = childWidth + extraSpace
-                else
-                    local extraSpace = math.floor(extraSpacePerUnit * child.get("flexGrow"))
-                    childWidth = childWidth + extraSpace
-                    distributedSpace = distributedSpace + extraSpace
+            local grow = child.get("flexGrow") or 0
+            if grow > 0 then
+                totalFlexGrow = totalFlexGrow + grow
+                table.insert(flexElements, {element = child, grow = grow})
+            else
+                table.insert(fixedElements, child)
+            end
+        end
+    end
+    
+    -- Step 2: Pre-processing before layout
+    -- First calculate the total width needed for all fixed elements
+    local fixedWidthSum = 0
+    for _, element in ipairs(fixedElements) do
+        fixedWidthSum = fixedWidthSum + element.get("width")
+    end
+    
+    -- Calculate total width of gaps
+    local totalElements = #fixedElements + #flexElements
+    local totalGaps = totalElements > 1 and (totalElements - 1) or 0
+    local gapsWidth = spacing * totalGaps
+    
+    -- Calculate total available space for flexible elements
+    local flexAvailableSpace = max(0, containerWidth - fixedWidthSum - gapsWidth)
+    
+    -- Safety check: If not enough space, force compress fixed elements
+    if flexAvailableSpace < 0 then
+        -- Set gaps to zero
+        gapsWidth = 0
+        flexAvailableSpace = containerWidth - fixedWidthSum
+        
+        -- If still not enough, need to shrink fixed elements
+        if flexAvailableSpace < 0 and #fixedElements > 0 then
+            local reductionPerElement = ceil(-flexAvailableSpace / #fixedElements)
+            for _, element in ipairs(fixedElements) do
+                local currentWidth = element.get("width")
+                local newWidth = max(1, currentWidth - reductionPerElement)
+                element.set("width", newWidth)
+                flexAvailableSpace = flexAvailableSpace + (currentWidth - newWidth)
+                if flexAvailableSpace >= 0 then
+                    break
                 end
             end
-
-            child.set("x", currentX)
-            child.set("y", children.offset or 1)
-            child.set("width", childWidth)
-            currentX = currentX + childWidth + spacing
+        end
+        
+        -- If still not enough, may need to set minimum width
+        flexAvailableSpace = max(0, flexAvailableSpace)
+    end
+    
+    -- Step 3: Allocate space for flexible elements
+    -- Pre-allocate table to avoid dynamic expansion
+    local allocatedWidths = {}
+    for i = 1, flexCount do
+        allocatedWidths[flexElements[i].element] = nil
+    end
+    
+    -- If there are flexible elements and available space
+    if #flexElements > 0 and flexAvailableSpace > 0 and totalFlexGrow > 0 then
+        -- Reserve some safety margin (e.g., 5% of space) to ensure no overflow due to rounding
+        local safeFlexSpace = floor(flexAvailableSpace * 0.95)
+        
+        -- Allocate base width for each element (conservative strategy)
+        for _, item in ipairs(flexElements) do
+            -- Determine this element's share
+            local proportion = item.grow / totalFlexGrow
+            -- Determine width to allocate (floor to ensure safety)
+            local extraWidth = floor(safeFlexSpace * proportion)
+            -- Set final width
+            allocatedWidths[item.element] = item.element.get("width") + extraWidth
         end
     end
-
-    if justifyContent == "flex-end" then
-        local offset = containerWidth - (currentX - spacing - 1)
-        for _, child in ipairs(children) do
-            child.set("x", child.get("x") + offset)
+    
+    -- Step 4: Strictly validate final widths
+    -- Calculate total width after allocation (including gaps)
+    local finalTotalWidth = gapsWidth
+    for _, element in ipairs(fixedElements) do
+        finalTotalWidth = finalTotalWidth + element.get("width")
+    end
+    for _, item in ipairs(flexElements) do
+        local width = allocatedWidths[item.element] or item.element.get("width")
+        finalTotalWidth = finalTotalWidth + width
+    end
+    
+    -- If total width exceeds container, proportionally reduce all elements
+    if finalTotalWidth > containerWidth then
+        local excessWidth = finalTotalWidth - containerWidth
+        local reductionFactor = excessWidth / (finalTotalWidth - gapsWidth)
+        
+        -- First reduce flexible elements
+        if #flexElements > 0 then
+            for _, item in ipairs(flexElements) do
+                local width = allocatedWidths[item.element] or item.element.get("width")
+                local reduction = ceil(width * reductionFactor)
+                allocatedWidths[item.element] = max(1, width - reduction)
+            end
         end
-    elseif justifyContent == "flex-center" or justifyContent == "center" then -- Akzeptiere beide Formate
-        local offset = math.floor((containerWidth - (currentX - spacing - 1)) / 2)
-        for _, child in ipairs(children) do
-            child.set("x", child.get("x") + offset)
+        
+        -- If still not enough, reduce fixed elements
+        finalTotalWidth = gapsWidth
+        for _, element in ipairs(fixedElements) do
+            finalTotalWidth = finalTotalWidth + element.get("width")
+        end
+        for _, item in ipairs(flexElements) do
+            finalTotalWidth = finalTotalWidth + (allocatedWidths[item.element] or item.element.get("width"))
+        end
+        
+        if finalTotalWidth > containerWidth and #fixedElements > 0 then
+            excessWidth = finalTotalWidth - containerWidth
+            reductionFactor = excessWidth / (finalTotalWidth - gapsWidth)
+            
+            for _, element in ipairs(fixedElements) do
+                local width = element.get("width")
+                local reduction = ceil(width * reductionFactor)
+                element.set("width", max(1, width - reduction))
+            end
+        end
+    end
+    
+    -- Step 5: Apply layout
+    local currentX = 1
+    
+    -- Place all elements
+    for _, child in ipairs(children) do
+        if child ~= lineBreakElement then
+            -- Apply X coordinate
+            child.set("x", currentX)
+            
+            -- Apply Y coordinate (based on vertical alignment)
+            if alignItems == "stretch" then
+                -- Vertical stretch to fill container, considering padding
+                child.set("height", availableCrossAxisSpace)
+                child.set("y", 1 + crossPadding)
+            else
+                local childHeight = child.get("height")
+                local y = 1
+                
+                if alignItems == "flex-end" then
+                    -- Bottom align
+                    y = containerHeight - childHeight + 1
+                elseif alignItems == "flex-center" or alignItems == "center" then
+                    -- Center align
+                    y = floor((containerHeight - childHeight) / 2) + 1
+                end
+                
+                -- Ensure Y value is not less than 1
+                child.set("y", max(1, y))
+            end
+            
+            -- If flexible element, apply calculated width
+            if allocatedWidths[child] then
+                child.set("width", allocatedWidths[child])
+            end
+            
+            -- Final safety check (using cached math functions)
+            local rightEdge = currentX + child.get("width") - 1
+            if rightEdge > containerWidth then
+                child.set("width", max(1, containerWidth - currentX + 1))
+            end
+            
+            -- Final safety check height doesn't exceed container
+            local bottomEdge = child.get("y") + child.get("height") - 1
+            if bottomEdge > containerHeight then
+                child.set("height", max(1, containerHeight - child.get("y") + 1))
+            end
+            
+            -- Update position for next element
+            currentX = currentX + child.get("width") + spacing
+            
+            -- Ensure won't exceed container right edge
+            if currentX > containerWidth + 1 then
+                currentX = containerWidth + 1
+            end
+        end
+    end
+    
+    -- Apply alignment (only when remaining space is positive)
+    local usedWidth = min(containerWidth, currentX - spacing - 1)
+    local remainingSpace = containerWidth - usedWidth
+    
+    if remainingSpace > 0 then
+        if justifyContent == "flex-end" then
+            for _, child in ipairs(children) do
+                if child ~= lineBreakElement then
+                    child.set("x", child.get("x") + remainingSpace)
+                end
+            end
+        elseif justifyContent == "flex-center" or justifyContent == "center" then
+            local offset = floor(remainingSpace / 2)
+            for _, child in ipairs(children) do
+                if child ~= lineBreakElement then
+                    child.set("x", child.get("x") + offset)
+                end
+            end
         end
     end
 end
 
 local function calculateColumn(self, children, spacing, justifyContent)
+    local containerWidth = self.get("width")
     local containerHeight = self.get("height")
-
-    local usedSpace = spacing * (#children - 1)
+    local alignItems = self.get("flexAlignItems")
+    local crossPadding = self.get("flexCrossPadding")
+    
+    -- Safety check
+    if containerHeight <= 0 then return end
+    
+    -- Calculate available cross axis space (considering padding)
+    local availableCrossAxisSpace = containerWidth - (crossPadding * 2)
+    if availableCrossAxisSpace < 1 then
+        availableCrossAxisSpace = containerWidth
+        crossPadding = 0
+    end
+    
+    -- Cache local variables to reduce function calls
+    local max = math.max
+    local min = math.min
+    local floor = math.floor
+    local ceil = math.ceil
+    
+    -- Fixed elements
+    local fixedElements = {}
+    -- Flexible elements
+    local flexElements = {}
+    -- Total flex coefficient
     local totalFlexGrow = 0
-
+    -- Pre-allocate capacity
+    local fixedCount = 0
+    local flexCount = 0
+    
+    -- First calculate element counts to pre-allocate space
     for _, child in ipairs(children) do
         if child ~= lineBreakElement then
-            usedSpace = usedSpace + child.get("height")
-            totalFlexGrow = totalFlexGrow + child.get("flexGrow")
+            local grow = child.get("flexGrow") or 0
+            if grow > 0 then
+                flexCount = flexCount + 1
+            else
+                fixedCount = fixedCount + 1
+            end
         end
     end
-
-    local remainingSpace = containerHeight - usedSpace
-    local extraSpacePerUnit = totalFlexGrow > 0 and (remainingSpace / totalFlexGrow) or 0
-    local distributedSpace = 0
-
-    local currentY = 1
-    for i, child in ipairs(children) do
+    
+    -- Pre-allocate table space
+    for i = 1, fixedCount do fixedElements[i] = nil end
+    
+    -- Step 1: Categorize elements and collect information
+    for _, child in ipairs(children) do
         if child ~= lineBreakElement then
-            local childHeight = child.get("height")
-
-            if child.get("flexGrow") > 0 then
-
-                if i == #children then
-                    local extraSpace = remainingSpace - distributedSpace
-                    childHeight = childHeight + extraSpace
-                else
-                    local extraSpace = math.floor(extraSpacePerUnit * child.get("flexGrow"))
-                    childHeight = childHeight + extraSpace
-                    distributedSpace = distributedSpace + extraSpace
+            local grow = child.get("flexGrow") or 0
+            if grow > 0 then
+                totalFlexGrow = totalFlexGrow + grow
+                table.insert(flexElements, {element = child, grow = grow})
+            else
+                table.insert(fixedElements, child)
+            end
+        end
+    end
+    
+    -- Step 2: Pre-processing before layout
+    
+    -- First calculate the total height needed for all fixed elements
+    local fixedHeightSum = 0
+    for _, element in ipairs(fixedElements) do
+        fixedHeightSum = fixedHeightSum + element.get("height")
+    end
+    
+    -- Calculate total height of gaps
+    local totalElements = #fixedElements + #flexElements
+    local totalGaps = totalElements > 1 and (totalElements - 1) or 0
+    local gapsHeight = spacing * totalGaps
+    
+    -- Calculate total available space for flexible elements
+    local flexAvailableSpace = max(0, containerHeight - fixedHeightSum - gapsHeight)
+    
+    -- Safety check: If not enough space, force compress fixed elements
+    if flexAvailableSpace < 0 then
+        -- Set gaps to zero
+        gapsHeight = 0
+        flexAvailableSpace = containerHeight - fixedHeightSum
+        
+        -- If still not enough, need to shrink fixed elements
+        if flexAvailableSpace < 0 and #fixedElements > 0 then
+            local reductionPerElement = ceil(-flexAvailableSpace / #fixedElements)
+            for _, element in ipairs(fixedElements) do
+                local currentHeight = element.get("height")
+                local newHeight = max(1, currentHeight - reductionPerElement)
+                element.set("height", newHeight)
+                flexAvailableSpace = flexAvailableSpace + (currentHeight - newHeight)
+                if flexAvailableSpace >= 0 then
+                    break
                 end
             end
-
-            child.set("x", children.offset or 1)
-            child.set("y", currentY)
-            child.set("height", childHeight)
-            currentY = currentY + childHeight + spacing
+        end
+        
+        -- If still not enough, may need to set minimum height
+        flexAvailableSpace = max(0, flexAvailableSpace)
+    end
+    
+    -- Step 3: Allocate space for flexible elements
+    -- Pre-allocate table to avoid dynamic expansion
+    local allocatedHeights = {}
+    for i = 1, flexCount do
+        allocatedHeights[flexElements[i].element] = nil
+    end
+    
+    -- If there are flexible elements and available space
+    if #flexElements > 0 and flexAvailableSpace > 0 and totalFlexGrow > 0 then
+        -- Reserve some safety margin (e.g., 5% of space) to ensure no overflow due to rounding
+        local safeFlexSpace = floor(flexAvailableSpace * 0.95)
+        
+        -- Allocate base height for each element (conservative strategy)
+        for _, item in ipairs(flexElements) do
+            -- Determine this element's share
+            local proportion = item.grow / totalFlexGrow
+            -- Determine height to allocate (floor to ensure safety)
+            local extraHeight = floor(safeFlexSpace * proportion)
+            -- Set final height
+            allocatedHeights[item.element] = item.element.get("height") + extraHeight
         end
     end
-
-    if justifyContent == "flex-end" then
-        local offset = containerHeight - (currentY - spacing - 1)
-        for _, child in ipairs(children) do
-            child.set("y", child.get("y") + offset)
+    
+    -- Step 4: Strictly validate final heights
+    -- Calculate total height after allocation (including gaps)
+    local finalTotalHeight = gapsHeight
+    for _, element in ipairs(fixedElements) do
+        finalTotalHeight = finalTotalHeight + element.get("height")
+    end
+    for _, item in ipairs(flexElements) do
+        local height = allocatedHeights[item.element] or item.element.get("height")
+        finalTotalHeight = finalTotalHeight + height
+    end
+    
+    -- If total height exceeds container, proportionally reduce all elements
+    if finalTotalHeight > containerHeight then
+        local excessHeight = finalTotalHeight - containerHeight
+        local reductionFactor = excessHeight / (finalTotalHeight - gapsHeight)
+        
+        -- First reduce flexible elements
+        if #flexElements > 0 then
+            for _, item in ipairs(flexElements) do
+                local height = allocatedHeights[item.element] or item.element.get("height")
+                local reduction = ceil(height * reductionFactor)
+                allocatedHeights[item.element] = max(1, height - reduction)
+            end
         end
-    elseif justifyContent == "flex-center" or justifyContent == "center" then -- Akzeptiere beide Formate
-        local offset = math.floor((containerHeight - (currentY - spacing - 1)) / 2)
-        for _, child in ipairs(children) do
-            child.set("y", child.get("y") + offset)
+        
+        -- If still not enough, reduce fixed elements
+        finalTotalHeight = gapsHeight
+        for _, element in ipairs(fixedElements) do
+            finalTotalHeight = finalTotalHeight + element.get("height")
+        end
+        for _, item in ipairs(flexElements) do
+            finalTotalHeight = finalTotalHeight + (allocatedHeights[item.element] or item.element.get("height"))
+        end
+        
+        if finalTotalHeight > containerHeight and #fixedElements > 0 then
+            excessHeight = finalTotalHeight - containerHeight
+            reductionFactor = excessHeight / (finalTotalHeight - gapsHeight)
+            
+            for _, element in ipairs(fixedElements) do
+                local height = element.get("height")
+                local reduction = ceil(height * reductionFactor)
+                element.set("height", max(1, height - reduction))
+            end
+        end
+    end
+    
+    -- Step 5: Apply layout
+    local currentY = 1
+    
+    -- Place all elements
+    for _, child in ipairs(children) do
+        if child ~= lineBreakElement then
+            -- Apply Y coordinate
+            child.set("y", currentY)
+            
+            -- Apply X coordinate (based on horizontal alignment)
+            if alignItems == "stretch" then
+                -- Horizontal stretch to fill container, considering padding
+                child.set("width", availableCrossAxisSpace)
+                child.set("x", 1 + crossPadding)
+            else
+                local childWidth = child.get("width")
+                local x = 1
+                
+                if alignItems == "flex-end" then
+                    -- Right align
+                    x = containerWidth - childWidth + 1
+                elseif alignItems == "flex-center" or alignItems == "center" then
+                    -- Center align
+                    x = floor((containerWidth - childWidth) / 2) + 1
+                end
+                
+                -- Ensure X value is not less than 1
+                child.set("x", max(1, x))
+            end
+            
+            -- If flexible element, apply calculated height
+            if allocatedHeights[child] then
+                child.set("height", allocatedHeights[child])
+            end
+            
+            -- Final safety check (using cached math functions)
+            local bottomEdge = currentY + child.get("height") - 1
+            if bottomEdge > containerHeight then
+                child.set("height", max(1, containerHeight - currentY + 1))
+            end
+            
+            -- Final safety check width doesn't exceed container
+            local rightEdge = child.get("x") + child.get("width") - 1
+            if rightEdge > containerWidth then
+                child.set("width", max(1, containerWidth - child.get("x") + 1))
+            end
+            
+            -- Update position for next element
+            currentY = currentY + child.get("height") + spacing
+            
+            -- Ensure won't exceed container bottom edge
+            if currentY > containerHeight + 1 then
+                currentY = containerHeight + 1
+            end
+        end
+    end
+    
+    -- Apply alignment (only when remaining space is positive)
+    local usedHeight = min(containerHeight, currentY - spacing - 1)
+    local remainingSpace = containerHeight - usedHeight
+    
+    if remainingSpace > 0 then
+        if justifyContent == "flex-end" then
+            for _, child in ipairs(children) do
+                if child ~= lineBreakElement then
+                    child.set("y", child.get("y") + remainingSpace)
+                end
+            end
+        elseif justifyContent == "flex-center" or justifyContent == "center" then
+            local offset = floor(remainingSpace / 2)
+            for _, child in ipairs(children) do
+                if child ~= lineBreakElement then
+                    child.set("y", child.get("y") + offset)
+                end
+            end
         end
     end
 end
 
+-- Optimize updateLayout function
 local function updateLayout(self, direction, spacing, justifyContent, wrap)
-  local elements = sortElements(self, direction, spacing, wrap)
-    if direction == "row" then
-        for _,v in pairs(elements)do
-            calculateRow(self, v, spacing, justifyContent)
-        end
-    else
-        for _,v in pairs(elements)do
-            calculateColumn(self, v, spacing, justifyContent)
-        end
+    -- Get all elements that need layout
+    local elements = sortElements(self, direction, spacing, wrap)
+    
+    -- Based on direction, select layout function, avoid checking every iteration
+    local layoutFunction = direction == "row" and calculateRow or calculateColumn
+    
+    -- Apply layout calculation
+    for _, rowOrColumn in pairs(elements) do
+        layoutFunction(self, rowOrColumn, spacing, justifyContent)
     end
+    
+    -- Reset layout update flag
     self.set("flexUpdateLayout", false)
 end
 

--- a/src/elements/Scrollbar.lua
+++ b/src/elements/Scrollbar.lua
@@ -1,77 +1,77 @@
 local VisualElement = require("elements/VisualElement")
 local tHex = require("libraries/colorHex")
 
----A scrollbar element that can be attached to other elements to control their scroll properties
----@class Scrollbar : VisualElement
-local Scrollbar = setmetatable({}, VisualElement)
-Scrollbar.__index = Scrollbar
+---A ScrollBar element that can be attached to other elements to control their scroll properties
+---@class ScrollBar : VisualElement
+local ScrollBar = setmetatable({}, VisualElement)
+ScrollBar.__index = ScrollBar
 
 ---@property value number 0 Current scroll value
-Scrollbar.defineProperty(Scrollbar, "value", {default = 0, type = "number", canTriggerRender = true})
+ScrollBar.defineProperty(ScrollBar, "value", {default = 0, type = "number", canTriggerRender = true})
 ---@property min number 0 Minimum scroll value
-Scrollbar.defineProperty(Scrollbar, "min", {default = 0, type = "number", canTriggerRender = true})
+ScrollBar.defineProperty(ScrollBar, "min", {default = 0, type = "number", canTriggerRender = true})
 ---@property max number 100 Maximum scroll value
-Scrollbar.defineProperty(Scrollbar, "max", {default = 100, type = "number", canTriggerRender = true})
+ScrollBar.defineProperty(ScrollBar, "max", {default = 100, type = "number", canTriggerRender = true})
 ---@property step number 1 Step size for scroll operations
-Scrollbar.defineProperty(Scrollbar, "step", {default = 10, type = "number"})
----@property dragMultiplier number 1 How fast the scrollbar moves when dragging
-Scrollbar.defineProperty(Scrollbar, "dragMultiplier", {default = 1, type = "number"})
----@property symbol string " " Symbol used for the scrollbar handle
-Scrollbar.defineProperty(Scrollbar, "symbol", {default = " ", type = "string", canTriggerRender = true})
----@property backgroundSymbol string "\127" Symbol used for the scrollbar background
-Scrollbar.defineProperty(Scrollbar, "symbolColor", {default = colors.gray, type = "color", canTriggerRender = true})
----@property symbolBackgroundColor color black Background color of the scrollbar handle
-Scrollbar.defineProperty(Scrollbar, "symbolBackgroundColor", {default = colors.black, type = "color", canTriggerRender = true})
----@property backgroundSymbol string "\127" Symbol used for the scrollbar background
-Scrollbar.defineProperty(Scrollbar, "backgroundSymbol", {default = "\127", type = "string", canTriggerRender = true})
----@property attachedElement table? nil The element this scrollbar is attached to
-Scrollbar.defineProperty(Scrollbar, "attachedElement", {default = nil, type = "table"})
+ScrollBar.defineProperty(ScrollBar, "step", {default = 10, type = "number"})
+---@property dragMultiplier number 1 How fast the ScrollBar moves when dragging
+ScrollBar.defineProperty(ScrollBar, "dragMultiplier", {default = 1, type = "number"})
+---@property symbol string " " Symbol used for the ScrollBar handle
+ScrollBar.defineProperty(ScrollBar, "symbol", {default = " ", type = "string", canTriggerRender = true})
+---@property backgroundSymbol string "\127" Symbol used for the ScrollBar background
+ScrollBar.defineProperty(ScrollBar, "symbolColor", {default = colors.gray, type = "color", canTriggerRender = true})
+---@property symbolBackgroundColor color black Background color of the ScrollBar handle
+ScrollBar.defineProperty(ScrollBar, "symbolBackgroundColor", {default = colors.black, type = "color", canTriggerRender = true})
+---@property backgroundSymbol string "\127" Symbol used for the ScrollBar background
+ScrollBar.defineProperty(ScrollBar, "backgroundSymbol", {default = "\127", type = "string", canTriggerRender = true})
+---@property attachedElement table? nil The element this ScrollBar is attached to
+ScrollBar.defineProperty(ScrollBar, "attachedElement", {default = nil, type = "table"})
 ---@property attachedProperty string? nil The property being controlled
-Scrollbar.defineProperty(Scrollbar, "attachedProperty", {default = nil, type = "string"})
+ScrollBar.defineProperty(ScrollBar, "attachedProperty", {default = nil, type = "string"})
 ---@property minValue number|function 0 Minimum value or function that returns it
-Scrollbar.defineProperty(Scrollbar, "minValue", {default = 0, type = "number"})
+ScrollBar.defineProperty(ScrollBar, "minValue", {default = 0, type = "number"})
 ---@property maxValue number|function 100 Maximum value or function that returns it
-Scrollbar.defineProperty(Scrollbar, "maxValue", {default = 100, type = "number"})
----@property orientation string vertical Orientation of the scrollbar ("vertical" or "horizontal")
-Scrollbar.defineProperty(Scrollbar, "orientation", {default = "vertical", type = "string", canTriggerRender = true})
+ScrollBar.defineProperty(ScrollBar, "maxValue", {default = 100, type = "number"})
+---@property orientation string vertical Orientation of the ScrollBar ("vertical" or "horizontal")
+ScrollBar.defineProperty(ScrollBar, "orientation", {default = "vertical", type = "string", canTriggerRender = true})
 
----@property handleSize number 2 Size of the scrollbar handle in characters
-Scrollbar.defineProperty(Scrollbar, "handleSize", {default = 2, type = "number", canTriggerRender = true})
+---@property handleSize number 2 Size of the ScrollBar handle in characters
+ScrollBar.defineProperty(ScrollBar, "handleSize", {default = 2, type = "number", canTriggerRender = true})
 
-Scrollbar.defineEvent(Scrollbar, "mouse_click")
-Scrollbar.defineEvent(Scrollbar, "mouse_release")
-Scrollbar.defineEvent(Scrollbar, "mouse_drag")
-Scrollbar.defineEvent(Scrollbar, "mouse_scroll")
+ScrollBar.defineEvent(ScrollBar, "mouse_click")
+ScrollBar.defineEvent(ScrollBar, "mouse_release")
+ScrollBar.defineEvent(ScrollBar, "mouse_drag")
+ScrollBar.defineEvent(ScrollBar, "mouse_scroll")
 
---- Creates a new Scrollbar instance
---- @shortDescription Creates a new Scrollbar instance
---- @return Scrollbar self The newly created Scrollbar instance
+--- Creates a new ScrollBar instance
+--- @shortDescription Creates a new ScrollBar instance
+--- @return ScrollBar self The newly created ScrollBar instance
 --- @private
-function Scrollbar.new()
-    local self = setmetatable({}, Scrollbar):__init()
-    self.class = Scrollbar
+function ScrollBar.new()
+    local self = setmetatable({}, ScrollBar):__init()
+    self.class = ScrollBar
     self.set("width", 1)
     self.set("height", 10)
     return self
 end
 
---- @shortDescription Initializes the Scrollbar instance
+--- @shortDescription Initializes the ScrollBar instance
 --- @param props table The properties to initialize the element with
 --- @param basalt table The basalt instance
---- @return Scrollbar self The initialized instance
+--- @return ScrollBar self The initialized instance
 --- @protected
-function Scrollbar:init(props, basalt)
+function ScrollBar:init(props, basalt)
     VisualElement.init(self, props, basalt)
-    self.set("type", "Scrollbar")
+    self.set("type", "ScrollBar")
     return self
 end
 
---- Attaches the scrollbar to an element's property
---- @shortDescription Attaches the scrollbar to an element's property
+--- Attaches the ScrollBar to an element's property
+--- @shortDescription Attaches the ScrollBar to an element's property
 --- @param element BaseElement The element to attach to
 --- @param config table Configuration {property = "propertyName", min = number|function, max = number|function}
---- @return Scrollbar self The scrollbar instance
-function Scrollbar:attach(element, config)
+--- @return ScrollBar self The ScrollBar instance
+function ScrollBar:attach(element, config)
     self.set("attachedElement", element)
     self.set("attachedProperty", config.property)
     self.set("minValue", config.min or 0)
@@ -79,10 +79,10 @@ function Scrollbar:attach(element, config)
     return self
 end
 
---- Updates the attached element's property based on the scrollbar value
---- @shortDescription Updates the attached element's property based on the scrollbar value
---- @return Scrollbar self The scrollbar instance
-function Scrollbar:updateAttachedElement()
+--- Updates the attached element's property based on the ScrollBar value
+--- @shortDescription Updates the attached element's property based on the ScrollBar value
+--- @return ScrollBar self The ScrollBar instance
+function ScrollBar:updateAttachedElement()
     local element = self.get("attachedElement")
     if not element then return end
 
@@ -113,7 +113,7 @@ end
 --- @param y number The y position of the click
 --- @return boolean Whether the event was handled
 --- @protected
-function Scrollbar:mouse_click(button, x, y)
+function ScrollBar:mouse_click(button, x, y)
     if VisualElement.mouse_click(self, button, x, y) then
         local size = getScrollbarSize(self)
         local value = self.get("value")
@@ -139,7 +139,7 @@ end
 --- @param y number The y position of the drag
 --- @return boolean Whether the event was handled
 --- @protected
-function Scrollbar:mouse_drag(button, x, y)
+function ScrollBar:mouse_drag(button, x, y)
     if(VisualElement.mouse_drag(self, button, x, y))then
         local size = getScrollbarSize(self)
         local handleSize = self.get("handleSize")
@@ -163,7 +163,7 @@ end
 --- @param y number The y position of the scroll
 --- @return boolean Whether the event was handled
 --- @protected
-function Scrollbar:mouse_scroll(direction, x, y)
+function ScrollBar:mouse_scroll(direction, x, y)
     if not self:isInBounds(x, y) then return false end
     direction = direction > 0 and -1 or 1
     local step = self.get("step")
@@ -175,9 +175,9 @@ function Scrollbar:mouse_scroll(direction, x, y)
     return true
 end
 
---- @shortDescription Renders the scrollbar
+--- @shortDescription Renders the ScrollBar
 --- @protected
-function Scrollbar:render()
+function ScrollBar:render()
     VisualElement.render(self)
 
     local size = getScrollbarSize(self)
@@ -208,4 +208,4 @@ function Scrollbar:render()
     end
 end
 
-return Scrollbar
+return ScrollBar

--- a/src/elements/Table.lua
+++ b/src/elements/Table.lua
@@ -183,7 +183,10 @@ function Table:render()
             for i, col in ipairs(columns) do
                 local cellText = tostring(rowData[i] or "")
                 local paddedText = cellText .. string.rep(" ", col.width - #cellText)
-                self:blit(currentX, y, string.sub(paddedText, 1, width-currentX+1),
+                if i < #columns then
+                    paddedText = string.sub(paddedText, 1, col.width - 1) .. " "
+                end
+                self:blit(currentX, y, string.sub(paddedText, 1, col.width),
                     string.sub(string.rep(tHex[self.get("foreground")], col.width), 1, width-currentX+1),
                     string.sub(string.rep(tHex[bg], col.width), 1, width-currentX+1))
                 currentX = currentX + col.width


### PR DESCRIPTION
# Pull Request

## Issue Fixed

There is a layout issue when the Flexbox changes size. The relevant script is as follows:

```lua
local main = basalt.getMainFrame()

local flexbox = main:addFlexbox({height = 20,width = 20}):setFlexDirection("column")

local button1 = flexbox:addButton({text = "add size"})
button1:onClick(function()
    flexbox:setHeight(flexbox:getHeight() + 1)
    flexbox:setWidth(flexbox:getWidth() + 1)
end):setFlexGrow(1)

local button2 = flexbox:addButton({text = "reduce size",background = colors.green})
button2:onClick(function()
    flexbox:setHeight(flexbox:getHeight() - 1)
    flexbox:setWidth(flexbox:getWidth() - 1)
end):setFlexGrow(1)

local button3 = flexbox:addButton({text = "last",background = colors.blue})
button3:onClick(function()

end):setFlexGrow(1)


basalt.run()
```

## New Features

The issue has been fixed, and the following new features have been added:

- `flexAlignItems` and `flexCrossPadding` on the `cross axis`