### PR TITLE
Fix crash when node has no value

### DIFF
--- a/src/plugins/xml.lua
+++ b/src/plugins/xml.lua
@@ -95,6 +95,7 @@ local function findExpressions(text)
 end
 
 local function convertValue(value, scope)
+    if not value then return value end
     if value:sub(1,1) == "\"" and value:sub(-1) == "\"" then
         value = value:sub(2, -2)
     end


### PR DESCRIPTION
I believe you forgot to add a line that prevents a pretty obvious error. This now lets you make nodes without a "value" field properly, meaning it's a lot easier to make single elements like buttons in XML.